### PR TITLE
fix: add BSD license classifier and correct setuptools-scm table

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Framework :: Flake8",
     "Environment :: Console",
     "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
@@ -55,7 +56,7 @@ dev = [
 [tool.setuptools.packages.find]
 where = ["src"]
 
-[tool.setuptools_scm]
+[tool.setuptools-scm]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
### Motivation
- Ensure project metadata correctly advertises the BSD-3-Clause license and that `setuptools-scm` is configured via the canonical `[tool.setuptools-scm]` table so version derivation and packaging behave correctly.

### Description
- Update `pyproject.toml` to add the `"License :: OSI Approved :: BSD License"` classifier and rename the config table to `[tool.setuptools-scm]` so tools reading the file can discover `setuptools-scm` configuration.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69871cb135508326837c27643188d161)