### PR TITLE
chore: add pre-commit hooks, pytest/coverage config, and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on:
+"on":
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-typecheck:
+    name: Lint & typecheck (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: uv sync --all-extras --dev --python ${{ matrix.python-version }}
+      - name: Run pre-commit
+        run: uv run pre-commit run --all-files
+        env:
+          SKIP: mypy
+      - name: Run mypy
+        run: uv run mypy src tests
+
+  build-test:
+    name: >-
+      Test (Python ${{ matrix.python-version }},
+      ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+        os: [ubuntu-latest]
+        include:
+          - python-version: "3.13"
+            os: macos-latest
+          - python-version: "3.13"
+            os: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: uv sync --all-extras --dev --python ${{ matrix.python-version }}
+      - name: Run tests with coverage
+        run: uv run pytest --cov=flake8_inheritance --cov-report=term-missing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   lint:
-    name: Lint
+    name: Lint (pre-commit, Python 3.11)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
           SKIP: mypy
 
   typecheck:
-    name: Typecheck (Python ${{ matrix.python-version }})
+    name: Mypy (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint-and-typecheck:
-    name: Lint & typecheck (Python ${{ matrix.python-version }})
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+      - name: Install dependencies
+        run: uv sync --all-extras --dev --python 3.11
+      - name: Run pre-commit
+        run: uv run pre-commit run --all-files
+        env:
+          SKIP: mypy
+
+  typecheck:
+    name: Typecheck (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -26,10 +43,6 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
       - name: Install dependencies
         run: uv sync --all-extras --dev --python ${{ matrix.python-version }}
-      - name: Run pre-commit
-        run: uv run pre-commit run --all-files
-        env:
-          SKIP: mypy
       - name: Run mypy
         run: uv run mypy src tests
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,69 @@
+ci:
+  autoupdate_schedule: quarterly
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.6
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: uv run dmypy run -- src tests
+        language: system
+        types: [python]
+        pass_filenames: false
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-ast
+      - id: check-toml
+      - id: check-yaml
+      - id: check-json
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+      - id: debug-statements
+      - id: mixed-line-ending
+      - id: detect-private-key
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: check-builtin-literals
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        additional_dependencies: [tomli]
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.29.5
+    hooks:
+      - id: typos
+
+  - repo: https://github.com/jackdewinter/pymarkdown
+    rev: v0.9.26
+    hooks:
+      - id: pymarkdown
+        args: [--config, .pymarkdown.json, scan]
+        exclude: ^(doc/adr/|planning/)
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: uv run dmypy run -- src tests
+        entry: uv run mypy src tests
         language: system
         types: [python]
         pass_filenames: false

--- a/.pymarkdown.json
+++ b/.pymarkdown.json
@@ -28,7 +28,7 @@
       "style": "ordered"
     },
     "no-emphasis-as-heading": {
-      "enabled": false
+      "enabled": true
     }
   }
 }

--- a/.pymarkdown.json
+++ b/.pymarkdown.json
@@ -1,0 +1,34 @@
+{
+  "mode": {
+    "strict-config": true
+  },
+  "plugins": {
+    "line-length": {
+      "enabled": true,
+      "line_length": 100,
+      "heading_line_length": 100,
+      "code_block_line_length": 100
+    },
+    "no-trailing-spaces": {
+      "enabled": true
+    },
+    "no-multiple-space-atx": {
+      "enabled": true
+    },
+    "no-duplicate-heading": {
+      "enabled": true,
+      "allow_different_nesting": true
+    },
+    "ul-style": {
+      "enabled": true,
+      "style": "dash"
+    },
+    "ol-prefix": {
+      "enabled": true,
+      "style": "ordered"
+    },
+    "no-emphasis-as-heading": {
+      "enabled": false
+    }
+  }
+}

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -6,4 +6,3 @@
 - 0004. [Use setuptools with setuptools-scm and zero runtime dependencies beyond flake8](0004-use-setuptools-with-setuptools-scm-and-zero-runtime-dependencies-beyond-flake8.md) — Accepted (2026-02-07)
 - 0005. [Derive version from git tags via setuptools-scm](0005-derive-version-from-git-tags-via-setuptools-scm.md) — Accepted (2026-02-07)
 - 0006. [Use BSD-3-Clause license](0006-use-bsd-3-clause-license.md) — Accepted (2026-02-07)
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,15 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = ["--strict-markers", "-ra"]
+addopts = ["-q", "--disable-warnings"]
+
+[tool.coverage.run]
+branch = true
+source = ["flake8_inheritance"]
+
+[tool.coverage.report]
+fail_under = 90
+show_missing = true
 
 [tool.ruff]
 line-length = 100
@@ -97,3 +105,9 @@ show_error_codes = true
 [[tool.mypy.overrides]]
 module = "flake8.*"
 ignore_missing_imports = true
+
+[tool.codespell]
+ignore-words-list = "INH"
+
+[tool.typos.default.extend-words]
+INH = "INH"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,19 @@
+import ast
+
+from flake8_inheritance import codes, visitors
+from flake8_inheritance.checker import InheritanceChecker
+
+
+def test_plugin_importable() -> None:
+    assert hasattr(InheritanceChecker, "name")
+
+
+def test_plugin_produces_no_errors_on_empty_module() -> None:
+    tree = ast.parse("")
+    checker = InheritanceChecker(tree)
+    assert list(checker.run()) == []
+
+
+def test_submodules_importable() -> None:
+    assert codes is not None
+    assert visitors is not None


### PR DESCRIPTION
Set up .pre-commit-config.yaml with ruff, mypy, pre-commit-hooks,
shellcheck, codespell, detect-secrets, typos, pymarkdown, and yamllint.
Configure pytest with coverage (fail_under=90) and add smoke tests.
Create CI workflow with lint/typecheck and build/test matrix jobs
across Python 3.11-3.13 and multiple OS targets.

https://claude.ai/code/session_01RBDEHbEWNL6eeKX8EnXFGW