### PR TITLE
Clarify CI job names for lint and mypy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   lint:
-    name: Lint
+    name: Lint (pre-commit, Python 3.11)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
           SKIP: mypy
 
   typecheck:
-    name: Typecheck (Python ${{ matrix.python-version }})
+    name: Mypy (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Motivation
- Make it explicit which CI steps run where by indicating that pre-commit (lint) runs on Python 3.11 while mypy runs across the Python-version matrix.

### Description
- Update job names in ` .github/workflows/ci.yml` to `Lint (pre-commit, Python 3.11)` and `Mypy (Python ${{ matrix.python-version }})` so the workflow labels accurately reflect the behavior.

### Testing
- No automated tests were run because this change only updates workflow job names.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987af81e8c8832693d78b770bd4bbd2)