### PR TITLE
Switch pre-commit mypy hook to plain mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: uv run dmypy run -- src tests
+        entry: uv run mypy src tests
         language: system
         types: [python]
         pass_filenames: false


### PR DESCRIPTION
### Motivation
- Replace `dmypy` with `mypy` in `.pre-commit-config.yaml` to avoid `.dmypy.*` state files and lingering daemon processes created by the dmypy daemon.

### Description
- Update the local pre-commit hook entry from `uv run dmypy run -- src tests` to `uv run mypy src tests` in `.pre-commit-config.yaml`.

### Testing
- No automated tests were run because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987b1fc1d50832690ff06a85b771224)