### PR TITLE
Add GitHub Actions publish workflow for release builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish
+
+"on":
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  release-build:
+    name: Build release artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Set up Python 3.13
+        run: uv python install 3.13
+      - name: Build
+        run: uv build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
+  pypi-publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: release-build
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           name: dist
           path: dist/*
+          if-no-files-found: error
 
   pypi-publish:
     name: Publish to PyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python 3.13
         run: uv python install 3.13
       - name: Build
-        run: uv build
+        run: uv build --python 3.13
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,8 @@ jobs:
     needs: release-build
     permissions:
       id-token: write
+      contents: read
+      actions: read
     environment:
       name: pypi
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,11 @@ name: Publish
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "publish" to confirm PyPI release'
+        required: true
+        default: ""
 
 jobs:
   release-build:
@@ -29,6 +34,11 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: release-build
+    if: >
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' &&
+      startsWith(github.ref, 'refs/tags/') &&
+      github.event.inputs.confirm == 'publish')
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 "on":
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
 
 jobs:

--- a/planning/plan.md
+++ b/planning/plan.md
@@ -232,7 +232,8 @@ commit SHAs or version tags.
 ### Task 1.7 — Create the publish workflow (`.github/workflows/publish.yml`)
 
 Create `.github/workflows/publish.yml` modeled on the decree project.
-Triggered on GitHub release creation and `workflow_dispatch`:
+Triggered on published GitHub releases and `workflow_dispatch` (with a
+confirmation input before publishing):
 
 **Jobs:**
 


### PR DESCRIPTION
### Motivation
- Provide a GitHub Actions workflow to build release artifacts and publish distributions to PyPI when a release is created or when manually dispatched.

### Description
- Add `.github/workflows/publish.yml` which triggers on `release` (type `created`) and `workflow_dispatch` and runs two jobs: `release-build` and `pypi-publish`.
- `release-build` checks out the repo, sets up Python 3.13 with `uv`, runs `uv build`, and uploads `dist/*` as artifacts using `actions/upload-artifact`.
- `pypi-publish` downloads the `dist` artifacts and publishes them to PyPI using `pypa/gh-action-pypi-publish@release/v1` with `id-token: write` permissions and the `pypi` environment.

### Testing
- No automated tests were run for this change because it only adds a CI workflow file and does not modify runtime code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987b759070c8326af1911a0b1b41e43)