### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    groups:
+      runtime:
+        dependency-type: "production"
+      dev-tools:
+        dependency-type: "development"
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "deps"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "deps"


### PR DESCRIPTION
### Motivation
- Enable automated weekly dependency updates for runtime packages, development tools, and GitHub Actions with consistent labels and commit message prefix for traceability.

### Description
- Add `.github/dependabot.yml` configuring Dependabot v2 for `uv` and `github-actions` with a weekly Monday `09:00` `America/Los_Angeles` schedule, groups `runtime` and `dev-tools`, labels `dependencies` and `security`, and commit message prefix `deps`.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987b79e45e8832681f7c0e41eb9075a)