### PR TITLE
Add Claude Code hooks and AI agent instructions

### DIFF
--- a/.claude/hooks/check-uv-prefix.py
+++ b/.claude/hooks/check-uv-prefix.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Hook: reject bare tool invocations that should use 'uv run'."""
+import json
+import sys
+
+data = json.load(sys.stdin)
+cmd = data.get("tool_input", {}).get("command", "")
+bare_tools = ["pytest", "pre-commit", "ruff ", "mypy "]
+for tool in bare_tools:
+    if tool in cmd and "uv run" not in cmd:
+        print(
+            f"Use 'uv run {tool.strip()}' instead of bare '{tool.strip()}'",
+            file=sys.stderr,
+        )
+        sys.exit(2)

--- a/.claude/hooks/post-change-reminder.py
+++ b/.claude/hooks/post-change-reminder.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Hook: remind to run pre-commit and tests after changes."""
+import sys
+
+print(
+    "REMINDER: Run 'uv run pre-commit run --all-files' "
+    "and 'uv run pytest' after changes.",
+    file=sys.stderr,
+)
+sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,22 @@
+{
+  "hooks": [
+    {
+      "event": "PreToolUse",
+      "matcher": "Bash",
+      "command": ".claude/hooks/check-uv-prefix.py"
+    },
+    {
+      "event": "PostToolUse",
+      "matcher": "Bash",
+      "command": ".claude/hooks/post-change-reminder.py"
+    },
+    {
+      "event": "Stop",
+      "command": "printf '\\a'"
+    },
+    {
+      "event": "Notification",
+      "command": "printf '\\a'"
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# CLAUDE.md — AI Agent Instructions for flake8-inheritance
+
+## Project Overview
+flake8-inheritance is a Flake8 plugin enforcing composition over
+inheritance in Python codebases.
+
+## Development Commands
+- Install: `uv sync --all-extras --dev`
+- Test: `uv run pytest`
+- Test with coverage: `uv run pytest --cov=flake8_inheritance --cov-report=term-missing`
+- Lint: `uv run pre-commit run --all-files`
+- Type check: `uv run mypy src`
+- Format: `uv run ruff format src tests`
+
+## CRITICAL RULES
+1. ALWAYS use `uv run` prefix for pytest, pre-commit, ruff, mypy
+2. After EVERY code change, run: `uv run pre-commit run --all-files`
+   then `uv run pytest`
+3. Use test-first TDD: write the failing test BEFORE the implementation
+4. All code must pass `ruff check`, `ruff format --check`, and
+   `mypy --strict`
+
+## Architecture
+- `src/flake8_inheritance/checker.py` — Flake8 plugin class
+- `src/flake8_inheritance/visitors.py` — AST visitors (no flake8 dependency)
+- `src/flake8_inheritance/codes.py` — Error code definitions (no flake8 dependency)
+- `tests/` — pytest test suite
+- `tests/fixtures/` — Sample Python files for testing
+
+## Design Principles
+- Composition over inheritance (we eat our own dogfood)
+- Core logic decoupled from flake8 (visitors.py and codes.py importable without flake8)
+- Zero runtime dependencies beyond flake8
+- Single-pass AST walk with O(1) lookups
+
+## ADRs
+Check `doc/adr/` for architectural decision records.
+Create new ADRs with: `decree new "Title of decision"`
+
+## Documentation
+Check `docs/` for project documentation. Read `docs/README.md` first.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Contributor Covenant Code of Conduct
 
-This project follows the [Contributor Covenant Code of Conduct, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+This project follows the [Contributor Covenant Code of Conduct, version 2.1].
 
 By participating in this project, you agree to abide by its terms.
 
@@ -17,3 +17,6 @@ This Code of Conduct is adapted from the
 [Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
 available at
 <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+[Contributor Covenant Code of Conduct, version 2.1]:
+  https://www.contributor-covenant.org/version/2/1/code_of_conduct/

--- a/doc/adr/0002-use-src-layout-for-package-structure.md
+++ b/doc/adr/0002-use-src-layout-for-package-structure.md
@@ -5,12 +5,22 @@ Status: Accepted
 
 ## Context
 
-Flake8 discovers plugins through entry points, which are only available after installation. If the plugin module is directly importable from the project root (flat layout), tests can pass by importing the module from the filesystem — bypassing entry point registration entirely. This means a misconfigured entry point would be invisible during development and only fail in production. The Python Packaging Authority recommends the `src` layout for this reason, and it is the standard used in the `decree` project.
+Flake8 discovers plugins through entry points, which are only available after
+installation. If the plugin module is directly importable from the project root
+(flat layout), tests can pass by importing the module from the filesystem —
+bypassing entry point registration entirely. This means a misconfigured entry
+point would be invisible during development and only fail in production. The
+Python Packaging Authority recommends the `src` layout for this reason, and it
+is the standard used in the `decree` project.
 
 ## Decision
 
-We will use the `src` layout with the importable package at `src/flake8_inheritance/`. All test and development workflows will install the package (editable install) to exercise entry point registration.
+We will use the `src` layout with the importable package at
+`src/flake8_inheritance/`. All test and development workflows will install the
+package (editable install) to exercise entry point registration.
 
 ## Consequences
 
-Tests cannot accidentally import uninstalled code. Entry point bugs are caught during development. The `[tool.setuptools.packages.find]` section in `pyproject.toml` must specify `where = ["src"]`.
+Tests cannot accidentally import uninstalled code. Entry point bugs are caught
+during development. The `[tool.setuptools.packages.find]` section in
+`pyproject.toml` must specify `where = ["src"]`.

--- a/doc/adr/0003-use-inh-as-error-code-prefix.md
+++ b/doc/adr/0003-use-inh-as-error-code-prefix.md
@@ -5,12 +5,24 @@ Status: Accepted
 
 ## Context
 
-Flake8 error codes consist of 1–3 uppercase letters followed by 1–3 digits. The letter prefix acts as a namespace, and the entry point name must be a prefix of all error codes the plugin produces. Single-letter prefixes have historically caused conflicts. The prefix must be unique across all published flake8 plugins. A search of the awesome-flake8-extensions list and PyPI found no existing plugin using the `INH` prefix.
+Flake8 error codes consist of 1–3 uppercase letters followed by 1–3 digits. The
+letter prefix acts as a namespace, and the entry point name must be a prefix of
+all error codes the plugin produces. Single-letter prefixes have historically
+caused conflicts. The prefix must be unique across all published flake8
+plugins. A search of the awesome-flake8-extensions list and PyPI found no
+existing plugin using the `INH` prefix.
 
 ## Decision
 
-We will use `INH` as the error code prefix. The flake8 entry point will be registered as `INH`. Error codes will be `INH001`, `INH002`, etc. Error code ranges are reserved: INH0xx for inheritance restrictions, INH1xx for ABC purity (INH002 retains its number for simplicity in v1), INH2xx reserved for future use.
+We will use `INH` as the error code prefix. The flake8 entry point will be
+registered as `INH`. Error codes will be `INH001`, `INH002`, etc. Error code
+ranges are reserved: INH0xx for inheritance restrictions, INH1xx for ABC
+purity (INH002 retains its number for simplicity in v1), INH2xx reserved for
+future use.
 
 ## Consequences
 
-All error codes must begin with `INH`. The entry point in `pyproject.toml` must be `INH = "flake8_inheritance.checker:InheritanceChecker"`. If a prefix collision is discovered before first release, all codes and the entry point must be renamed.
+All error codes must begin with `INH`. The entry point in `pyproject.toml` must
+be `INH = "flake8_inheritance.checker:InheritanceChecker"`. If a prefix
+collision is discovered before first release, all codes and the entry point
+must be renamed.

--- a/doc/adr/0004-use-setuptools-with-setuptools-scm-and-zero-runtime-dependencies-beyond-flake8.md
+++ b/doc/adr/0004-use-setuptools-with-setuptools-scm-and-zero-runtime-dependencies-beyond-flake8.md
@@ -5,12 +5,27 @@ Status: Accepted
 
 ## Context
 
-The plugin needs a build system, a version management strategy, and a dependency policy. `setuptools` is the most widely used build backend and has mature support for entry points. `setuptools-scm` derives versions from git tags, eliminating hardcoded version strings and ensuring published packages always correspond to tagged commits. For runtime dependencies, minimalism is a hallmark of well-maintained flake8 plugins — `flake8-bugbear`, the most respected plugin in the ecosystem, depends only on `flake8` and uses stdlib-only logic. Additional runtime dependencies increase the attack surface and risk version conflicts in user environments.
+The plugin needs a build system, a version management strategy, and a
+dependency policy. `setuptools` is the most widely used build backend and has
+mature support for entry points. `setuptools-scm` derives versions from git
+tags, eliminating hardcoded version strings and ensuring published packages
+always correspond to tagged commits. For runtime dependencies, minimalism is a
+hallmark of well-maintained flake8 plugins — `flake8-bugbear`, the most
+respected plugin in the ecosystem, depends only on `flake8` and uses
+stdlib-only logic. Additional runtime dependencies increase the attack surface
+and risk version conflicts in user environments.
 
 ## Decision
 
-We will use `setuptools>=77` as the build backend with `setuptools-scm>=8` for version derivation. The only runtime dependency will be `flake8>=6.0`. All core plugin logic will use only the Python standard library (`ast`, `sys`, `dataclasses`, `importlib.metadata`). Development and test dependencies are declared in `[project.optional-dependencies]` and are not required at runtime.
+We will use `setuptools>=77` as the build backend with `setuptools-scm>=8` for
+version derivation. The only runtime dependency will be `flake8>=6.0`. All core
+plugin logic will use only the Python standard library (`ast`, `sys`,
+`dataclasses`, `importlib.metadata`). Development and test dependencies are
+declared in `[project.optional-dependencies]` and are not required at runtime.
 
 ## Consequences
 
-Versions are derived from git tags — there must never be a hardcoded version string in the source tree. Releases require `git tag vX.Y.Z` before building. The plugin can be installed in any environment where flake8 runs with no additional dependencies to resolve.
+Versions are derived from git tags — there must never be a hardcoded version
+string in the source tree. Releases require `git tag vX.Y.Z` before building.
+The plugin can be installed in any environment where flake8 runs with no
+additional dependencies to resolve.

--- a/doc/adr/0005-derive-version-from-git-tags-via-setuptools-scm.md
+++ b/doc/adr/0005-derive-version-from-git-tags-via-setuptools-scm.md
@@ -5,12 +5,24 @@ Status: Accepted
 
 ## Context
 
-Hardcoded version strings in source code create a maintenance burden and a category of release errors — forgetting to bump the version, or bumping it inconsistently across files. The plugin's version appears in `flake8 --version` output, so it must be accurate. `setuptools-scm` derives the version from git tags at build time, and `importlib.metadata.version()` reads it at runtime from the installed package metadata.
+Hardcoded version strings in source code create a maintenance burden and a
+category of release errors — forgetting to bump the version, or bumping it
+inconsistently across files. The plugin's version appears in
+`flake8 --version` output, so it must be accurate. `setuptools-scm` derives the
+version from git tags at build time, and `importlib.metadata.version()` reads
+it at runtime from the installed package metadata.
 
 ## Decision
 
-We will use `setuptools-scm` for version derivation with `dynamic = ["version"]` in `pyproject.toml`. The checker class will read the version at import time via `importlib.metadata.version("flake8-inheritance")`. There will be no hardcoded version string anywhere in the source tree.
+We will use `setuptools-scm` for version derivation with
+`dynamic = ["version"]` in `pyproject.toml`. The checker class will read the
+version at import time via
+`importlib.metadata.version("flake8-inheritance")`. There will be no hardcoded
+version string anywhere in the source tree.
 
 ## Consequences
 
-Every release requires a git tag (`vX.Y.Z`) before building. Development installs show a dev version with the git hash. CI must use `fetch-depth: 0` when checking out the repository so that setuptools-scm can read the full tag history.
+Every release requires a git tag (`vX.Y.Z`) before building. Development
+installs show a dev version with the git hash. CI must use `fetch-depth: 0`
+when checking out the repository so that setuptools-scm can read the full tag
+history.

--- a/doc/adr/0006-use-bsd-3-clause-license.md
+++ b/doc/adr/0006-use-bsd-3-clause-license.md
@@ -5,12 +5,19 @@ Status: Accepted
 
 ## Context
 
-The plugin will be published as open-source on PyPI. The license choice affects adoption and contribution. BSD-3-Clause is permissive, well-understood, compatible with virtually all downstream uses, and is the license used by the `decree` project. It does not impose copyleft obligations, which makes it easier for companies to adopt the plugin in proprietary CI pipelines.
+The plugin will be published as open-source on PyPI. The license choice affects
+adoption and contribution. BSD-3-Clause is permissive, well-understood,
+compatible with virtually all downstream uses, and is the license used by the
+`decree` project. It does not impose copyleft obligations, which makes it
+easier for companies to adopt the plugin in proprietary CI pipelines.
 
 ## Decision
 
-We will license flake8-inheritance under the BSD-3-Clause license, consistent with the decree project.
+We will license flake8-inheritance under the BSD-3-Clause license, consistent
+with the decree project.
 
 ## Consequences
 
-The license file must be included in the repository root. The `license` field in `pyproject.toml` must be `"BSD-3-Clause"`. The PyPI classifier must be `"License :: OSI Approved :: BSD License"`.
+The license file must be included in the repository root. The `license` field
+in `pyproject.toml` must be `"BSD-3-Clause"`. The PyPI classifier must be
+`"License :: OSI Approved :: BSD License"`.

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -1,8 +1,17 @@
 # Architecture decision records
 
-- 0001. [Record architecture decisions](0001-record-architecture-decisions.md) — Accepted (2026-02-07)
-- 0002. [Use src layout for package structure](0002-use-src-layout-for-package-structure.md) — Accepted (2026-02-07)
-- 0003. [Use INH as error code prefix](0003-use-inh-as-error-code-prefix.md) — Accepted (2026-02-07)
-- 0004. [Use setuptools with setuptools-scm and zero runtime dependencies beyond flake8](0004-use-setuptools-with-setuptools-scm-and-zero-runtime-dependencies-beyond-flake8.md) — Accepted (2026-02-07)
-- 0005. [Derive version from git tags via setuptools-scm](0005-derive-version-from-git-tags-via-setuptools-scm.md) — Accepted (2026-02-07)
-- 0006. [Use BSD-3-Clause license](0006-use-bsd-3-clause-license.md) — Accepted (2026-02-07)
+- 0001. [Record architecture decisions](0001-record-architecture-decisions.md) —
+  Accepted (2026-02-07)
+- 0002. [Use src layout for package structure](
+  0002-use-src-layout-for-package-structure.md) — Accepted (2026-02-07)
+- 0003. [Use INH as error code prefix](0003-use-inh-as-error-code-prefix.md) —
+  Accepted (2026-02-07)
+- 0004. [Use setuptools with setuptools-scm and zero runtime dependencies beyond
+  flake8](
+  0004-use-setuptools-with-setuptools-scm-and-zero-runtime-dependencies-beyond-flake8.md)
+  — Accepted (2026-02-07)
+- 0005. [Derive version from git tags via setuptools-scm](
+  0005-derive-version-from-git-tags-via-setuptools-scm.md) — Accepted
+  (2026-02-07)
+- 0006. [Use BSD-3-Clause license](0006-use-bsd-3-clause-license.md) — Accepted
+  (2026-02-07)

--- a/planning/plan.md
+++ b/planning/plan.md
@@ -82,9 +82,18 @@ instead of the hardcoded string. Remove any hardcoded version strings from
 the source tree.
 
 **Done when:**
-`python -c "import flake8_inheritance; from importlib.metadata import version; print(version('flake8-inheritance'))"`
-prints a version derived from the git tag, and
-`grep -r "0\.0\.0" src/` returns nothing.
+
+```bash
+python - <<'PY'
+from importlib.metadata import version
+import flake8_inheritance
+
+print(version("flake8-inheritance"))
+PY
+```
+
+prints a version derived from the git tag, and `grep -r "0\.0\.0" src/`
+returns nothing.
 
 ---
 
@@ -465,8 +474,10 @@ write the failing test, then implement.
 and a `format(**kwargs)` method. Define `INH001` and `INH002` with their
 message templates:
 
-- `INH001`: `"Inheritance from internal class '{base}' is not allowed (use composition instead)"`
-- `INH002`: `"Abstract base class '{cls}' contains concrete method '{method}' (ABCs should only define abstract methods)"`
+- `INH001`: `"Inheritance from internal class '{base}' is not allowed (use
+  composition instead)"`
+- `INH002`: `"Abstract base class '{cls}' contains concrete method '{method}'
+  (ABCs should only define abstract methods)"`
 
 **Run:** `uv run pytest tests/test_codes.py` and
 `uv run pre-commit run --all-files`.
@@ -752,8 +763,8 @@ Add a table documenting all error codes:
 
 | Code | Description | Triggers when… | Fix by… |
 |------|-------------|-----------------|---------|
-| INH001 | Inheritance from internal class | A class inherits from same-file, relative import, or configured project package class | Replace inheritance with composition |
-| INH002 | Concrete method in ABC | An ABC contains a method without `@abstractmethod` | Add `@abstractmethod` or extract to utility |
+| INH001 | Internal inheritance | Inherits from same-file/relative/project class | Use composition |
+| INH002 | Non-abstract ABC method | ABC has method without @abstractmethod | Add @abstractmethod |
 
 Include triggering and fixed code examples for each.
 


### PR DESCRIPTION
### Motivation
- Provide Claude Code configuration to enforce development conventions (always use `uv run` for test/lint/type commands) and to remind contributors to run checks after edits.
- Supply a clear AI agent instruction document to standardize automated assistance and local development workflows.

### Description
- Add `.claude/settings.json` to wire `PreToolUse` and `PostToolUse` hooks and to configure optional `Stop`/`Notification` sound commands.
- Add executable hook `.claude/hooks/check-uv-prefix.py` that rejects bare invocations of `pytest`, `pre-commit`, `ruff`, and `mypy` unless prefixed with `uv run`.
- Add executable hook `.claude/hooks/post-change-reminder.py` that prints a reminder to run `uv run pre-commit run --all-files` and `uv run pytest` after changes.
- Add `CLAUDE.md` with AI agent instructions, development commands, architecture notes, and critical rules for contributors.

### Testing
- No automated tests were run for these repository metadata and documentation changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987ba0605c48326a5d1de10ac53f679)