### PR TITLE
Require tag and confirmation for manual PyPI publishes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,11 @@ name: Publish
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "publish" to confirm PyPI release'
+        required: true
+        default: ""
 
 jobs:
   release-build:
@@ -29,6 +34,11 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: release-build
+    if: >
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' &&
+      startsWith(github.ref, 'refs/tags/') &&
+      github.event.inputs.confirm == 'publish')
     permissions:
       id-token: write
       contents: read

--- a/planning/plan.md
+++ b/planning/plan.md
@@ -232,7 +232,8 @@ commit SHAs or version tags.
 ### Task 1.7 — Create the publish workflow (`.github/workflows/publish.yml`)
 
 Create `.github/workflows/publish.yml` modeled on the decree project.
-Triggered on GitHub release creation and `workflow_dispatch`:
+Triggered on published GitHub releases and `workflow_dispatch` (with a
+confirmation input before publishing):
 
 **Jobs:**
 


### PR DESCRIPTION
### Motivation
- Align the workflow behavior and documentation so publishing runs on published GitHub releases and to prevent accidental PyPI publishes from arbitrary refs when using `workflow_dispatch`.
- Add an explicit confirmation to make manual dispatches deliberate and auditable.

### Description
- Add a `confirm` input to `workflow_dispatch` in ` .github/workflows/publish.yml` that requires typing `publish` to approve a manual run.
- Add an `if` guard to the `pypi-publish` job so it runs only for `release` events or for `workflow_dispatch` when the ref is a tag and `github.event.inputs.confirm == 'publish'`.
- Update `planning/plan.md` to document that the publish workflow is triggered on published releases and that manual dispatch requires confirmation.

### Testing
- No automated tests were run because this is a workflow and documentation change only; changes are ready for review and validation via GitHub Actions (or `actionlint`) in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987ceb961bc83269b2ab80004c5804f)