### PR TITLE
Fix Claude hooks and markdown formatting

### DIFF
--- a/.claude/hooks/check-uv-prefix.py
+++ b/.claude/hooks/check-uv-prefix.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Hook: reject bare tool invocations that should use 'uv run'."""
+
+import json
+import re
+import sys
+
+data = json.load(sys.stdin)
+cmd = data.get("tool_input", {}).get("command", "")
+bare_tools = ["pytest", "pre-commit", "ruff", "mypy"]
+needs_uv_run = not re.search(r"\buv\s+run\b", cmd)
+for tool in bare_tools:
+    if needs_uv_run and re.search(rf"\b{re.escape(tool)}\b", cmd):
+        sys.stderr.write(f"Use 'uv run {tool.strip()}' instead of bare '{tool.strip()}'\n")
+        sys.exit(2)

--- a/.claude/hooks/check-uv-prefix.py
+++ b/.claude/hooks/check-uv-prefix.py
@@ -8,8 +8,16 @@ import sys
 data = json.load(sys.stdin)
 cmd = data.get("tool_input", {}).get("command", "")
 bare_tools = ["pytest", "pre-commit", "ruff", "mypy"]
-needs_uv_run = not re.search(r"\buv\s+run\b", cmd)
-for tool in bare_tools:
-    if needs_uv_run and re.search(rf"\b{re.escape(tool)}\b", cmd):
-        sys.stderr.write(f"Use 'uv run {tool.strip()}' instead of bare '{tool.strip()}'\n")
-        sys.exit(2)
+
+# Split the command into segments (e.g., separated by &&, ;, |) and
+# ensure any tool usage in a segment is guarded by 'uv run' in that segment.
+segments = re.split(r"[;&|]+", cmd)
+for segment in segments:
+    segment = segment.strip()
+    if not segment:
+        continue
+    has_uv_run = re.search(r"\buv\s+run\b", segment)
+    for tool in bare_tools:
+        if re.search(rf"\b{re.escape(tool)}\b", segment) and not has_uv_run:
+            sys.stderr.write(f"Use 'uv run {tool.strip()}' instead of bare '{tool.strip()}'\n")
+            sys.exit(2)

--- a/.claude/hooks/check-uv-prefix.py
+++ b/.claude/hooks/check-uv-prefix.py
@@ -13,11 +13,11 @@ bare_tools = ["pytest", "pre-commit", "ruff", "mypy"]
 # ensure any tool usage in a segment is guarded by 'uv run' in that segment.
 segments = re.split(r"[;&|]+", cmd)
 for segment in segments:
-    segment = segment.strip()
-    if not segment:
+    segment_stripped = segment.strip()
+    if not segment_stripped:
         continue
-    has_uv_run = re.search(r"\buv\s+run\b", segment)
+    has_uv_run = re.search(r"\buv\s+run\b", segment_stripped)
     for tool in bare_tools:
-        if re.search(rf"\b{re.escape(tool)}\b", segment) and not has_uv_run:
+        if re.search(rf"\b{re.escape(tool)}\b", segment_stripped) and not has_uv_run:
             sys.stderr.write(f"Use 'uv run {tool.strip()}' instead of bare '{tool.strip()}'\n")
             sys.exit(2)

--- a/.claude/hooks/post-change-reminder.py
+++ b/.claude/hooks/post-change-reminder.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Hook: remind to run pre-commit and tests after changes."""
+
+import sys
+
+sys.stderr.write(
+    "Remember: run 'uv run pre-commit run --all-files' and 'uv run pytest' to validate changes.\n"
+)
+sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "command": "python3 .claude/hooks/check-uv-prefix.py"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "command": "python3 .claude/hooks/post-change-reminder.py"
+      }
+    ],
+    "Stop": [
+      {
+        "command": "printf '\u0007'"
+      }
+    ],
+    "Notification": [
+      {
+        "command": "printf '\u0007'"
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,4 +45,4 @@ Create new ADRs with: `decree new "Title of decision"`
 
 ## Documentation
 
-Check `docs/` for project documentation. Read `docs/README.md` first.
+Check `doc/` for project documentation. Read `doc/README.md` first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md — AI Agent Instructions for flake8-inheritance
+
+## Project Overview
+
+flake8-inheritance is a Flake8 plugin enforcing composition over inheritance in Python
+codebases.
+
+## Development Commands
+
+- Install: `uv sync --all-extras --dev`
+- Test: `uv run pytest`
+- Test with coverage: `uv run pytest --cov=flake8_inheritance --cov-report=term-missing`
+- Lint: `uv run pre-commit run --all-files`
+- Type check: `uv run mypy src`
+- Format: `uv run ruff format src tests`
+
+## CRITICAL RULES
+
+1. ALWAYS use `uv run` prefix for pytest, pre-commit, ruff, mypy
+2. After EVERY code change, run: `uv run pre-commit run --all-files`
+   then `uv run pytest`
+3. Use test-first TDD: write the failing test BEFORE the implementation
+4. All code must pass `ruff check`, `ruff format --check`, and
+   `mypy --strict`
+
+## Architecture
+
+- `src/flake8_inheritance/checker.py` — Flake8 plugin class
+- `src/flake8_inheritance/visitors.py` — AST visitors (no flake8 dependency)
+- `src/flake8_inheritance/codes.py` — Error code definitions (no flake8 dependency)
+- `tests/` — pytest test suite
+- `tests/fixtures/` — Sample Python files for testing
+
+## Design Principles
+
+- Composition over inheritance (we eat our own dogfood)
+- Core logic decoupled from flake8 (visitors.py and codes.py importable without flake8)
+- Zero runtime dependencies beyond flake8
+- Single-pass AST walk with O(1) lookups
+
+## ADRs
+
+Check `doc/adr/` for architectural decision records.
+Create new ADRs with: `decree new "Title of decision"`
+
+## Documentation
+
+Check `docs/` for project documentation. Read `docs/README.md` first.


### PR DESCRIPTION
### Motivation
- Ensure the Claude hook scripts follow project lint rules and reliably detect bare tool invocations that must be prefixed with `uv run`.
- Replace `print` usage in hooks to satisfy `ruff` T201 and produce deterministic stderr output for hook tooling.
- Fix Markdown formatting in `CLAUDE.md` so it passes the Markdown linter used by pre-commit.

### Description
- Tightened `.claude/hooks/check-uv-prefix.py` to use word-boundary regex matching, detect whether `uv run` is present, and emit errors via `sys.stderr.write`; also normalized the `bare_tools` list to avoid accidental substring matches.
- Replaced `print` in `.claude/hooks/post-change-reminder.py` with `sys.stderr.write` and adjusted the reminder message text to a single-line message ending with a newline.
- Added missing blank lines around headings and lists in `CLAUDE.md` to satisfy `pymarkdown` rules and improve readability.

### Testing
- Ran `uv run pytest` and all tests passed (`3 passed`).
- Ran `uv run pre-commit run --all-files`; initial lint failures from `ruff` and `pymarkdown` were fixed by the code updates and the final run passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988331d453c832696a170ff2076efdd)