### PR TITLE
Avoid loop-variable reassignment in uv-prefix hook (fix ruff warning)

### DIFF
--- a/.claude/hooks/check-uv-prefix.py
+++ b/.claude/hooks/check-uv-prefix.py
@@ -13,11 +13,11 @@ bare_tools = ["pytest", "pre-commit", "ruff", "mypy"]
 # ensure any tool usage in a segment is guarded by 'uv run' in that segment.
 segments = re.split(r"[;&|]+", cmd)
 for segment in segments:
-    segment = segment.strip()
-    if not segment:
+    segment_stripped = segment.strip()
+    if not segment_stripped:
         continue
-    has_uv_run = re.search(r"\buv\s+run\b", segment)
+    has_uv_run = re.search(r"\buv\s+run\b", segment_stripped)
     for tool in bare_tools:
-        if re.search(rf"\b{re.escape(tool)}\b", segment) and not has_uv_run:
+        if re.search(rf"\b{re.escape(tool)}\b", segment_stripped) and not has_uv_run:
             sys.stderr.write(f"Use 'uv run {tool.strip()}' instead of bare '{tool.strip()}'\n")
             sys.exit(2)


### PR DESCRIPTION
### Motivation
- Silence a ruff PLW2901 warning about reassigning the loop variable in the uv-prefix hook so pre-commit checks pass.

### Description
- Rename the stripped copy of each segment to `segment_stripped` and use it for empty checks and regex searches in `.claude/hooks/check-uv-prefix.py` instead of reassigning `segment`.

### Testing
- Ran `uv run py.test` which passed; ran `uv run pre-commit run --all-files` which also passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698850782c9483268bc806704553170c)