### PR TITLE
Add docs/ directory with AI-readable developer documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Developer Documentation
+
+Internal documentation for contributors and AI agents working on
+flake8-inheritance.
+
+## Contents
+
+| Document | Description |
+|---|---|
+| [architecture.md](architecture.md) | Module responsibilities, data flow, and design principles |
+| [flake8-plugin-contract.md](flake8-plugin-contract.md) | How flake8 discovers and invokes the plugin |
+| [error-codes.md](error-codes.md) | INH error code reference with examples |
+
+## See Also
+
+- [../README.md](../README.md) -- Project overview and user-facing docs
+- [../CONTRIBUTING.md](../CONTRIBUTING.md) -- Development setup and workflow
+- [../CLAUDE.md](../CLAUDE.md) -- AI agent instructions
+- [../doc/adr/](../doc/adr/) -- Architectural decision records

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ flake8-inheritance.
 | Document | Description |
 |---|---|
 | [architecture.md](architecture.md) | Module responsibilities, data flow, and design principles |
-| [flake8-plugin-contract.md](flake8-plugin-contract.md) | How flake8 discovers and invokes the plugin |
+| [flake8-plugin-contract.md](flake8-plugin-contract.md) | How flake8 discovers and invokes plugins |
 | [error-codes.md](error-codes.md) | INH error code reference with examples |
 
 ## See Also

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,88 @@
+# Architecture
+
+## Module Map
+
+```text
+src/flake8_inheritance/
+├── __init__.py        # Package marker; re-exports nothing
+├── checker.py         # Flake8 plugin entry point (depends on flake8)
+├── codes.py           # Error code constants (stdlib only)
+└── visitors.py        # AST visitor logic (stdlib only)
+```
+
+### checker.py
+
+Contains `InheritanceChecker`, the sole class registered with flake8.
+It receives a parsed AST via `__init__` and yields diagnostics from
+`run()`. This module is the only one that depends on flake8.
+
+### visitors.py
+
+Houses the AST walking logic. Visitors operate on `ast.AST` nodes and
+return findings as plain data (no flake8 types). This separation means
+the core detection logic can be tested and used without flake8 installed.
+
+### codes.py
+
+Defines error code constants (message strings keyed by code). Keeping
+codes in their own module avoids circular imports and makes it easy for
+other tools to enumerate available diagnostics.
+
+## Dependency Rule
+
+```text
+checker.py  -->  visitors.py  -->  (stdlib only)
+     |                              codes.py  -->  (stdlib only)
+     v
+  flake8
+```
+
+Only `checker.py` imports from flake8. Both `visitors.py` and `codes.py`
+are importable with nothing beyond the standard library. This is enforced
+by a smoke test in the test suite.
+
+## Data Flow
+
+```text
+1. flake8 parses a Python file into an ast.Module
+2. flake8 instantiates InheritanceChecker(tree=<ast.Module>)
+3. flake8 calls checker.run()
+4. run() delegates to visitors, passing the stored AST
+5. Visitors walk the tree, collecting class definitions that inherit
+   from non-exempt bases
+6. run() yields (line, col, message, type) tuples back to flake8
+```
+
+## Error Code Ranges
+
+| Range | Category |
+|---|---|
+| INH0xx | Inheritance restriction rules |
+| INH1xx | ABC purity checks |
+| INH2xx | Reserved for future use |
+
+See [error-codes.md](error-codes.md) for individual code details.
+
+## Design Principles
+
+1. **Composition over inheritance** -- the plugin eats its own dogfood.
+   `InheritanceChecker` does not subclass any flake8 base class; it
+   satisfies the plugin contract through duck typing.
+
+2. **Single-pass AST walk** -- one traversal of the tree, O(1) lookups
+   for exempt bases.
+
+3. **Zero runtime dependencies beyond flake8** -- the plugin adds no
+   transitive dependencies to a user's environment.
+
+4. **Decouple core logic from flake8** -- visitors and codes are
+   testable in isolation without flake8 installed.
+
+## Key ADRs
+
+- [ADR-0002](../doc/adr/0002-use-src-layout-for-package-structure.md) --
+  src layout
+- [ADR-0007](../doc/adr/0007-use-composition-over-inheritance-as-the-core-design-principle.md) --
+  composition over inheritance as design principle
+- [ADR-0008](../doc/adr/0008-use-flake8-ast-checker-plugin-architecture.md) --
+  AST checker architecture

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1,0 +1,92 @@
+# Error Codes
+
+Reference for all diagnostics produced by flake8-inheritance.
+
+## INH001 -- Class inherits from a concrete class
+
+**Status:** Planned
+
+**What it detects:** A class definition that inherits from a concrete
+(non-abstract, non-exempt) base class defined within the same project.
+
+**Rationale:** Inheriting from concrete classes creates tight coupling.
+Composition (holding a reference and delegating) is usually more flexible
+and easier to test.
+
+### Triggers
+
+```python
+class Engine:
+    def start(self) -> None: ...
+
+class TurboEngine(Engine):  # <-- INH001
+    def start(self) -> None: ...
+```
+
+### Fix
+
+```python
+class Engine:
+    def start(self) -> None: ...
+
+class TurboEngine:
+    def __init__(self, base: Engine) -> None:
+        self._base = base
+
+    def start(self) -> None:
+        self._base.start()
+```
+
+### Exemptions
+
+Classes inheriting from the following are **not** flagged:
+
+- Abstract base classes (`ABC`, `ABCMeta`)
+- Exception classes (`Exception`, `BaseException`, and subclasses)
+- Framework bases specified via configuration (e.g. Pydantic, Django,
+  SQLAlchemy model bases)
+- Bases imported from external (non-project) packages
+
+---
+
+## INH002 -- Abstract class should use ABC
+
+**Status:** Planned
+
+**What it detects:** A class that defines `@abstractmethod`-decorated
+methods but does not inherit from `abc.ABC` or use `abc.ABCMeta` as its
+metaclass.
+
+**Rationale:** Without `ABC`/`ABCMeta`, Python will not prevent
+instantiation of the incomplete class, silently defeating the purpose of
+abstract methods.
+
+### Triggers
+
+```python
+from abc import abstractmethod
+
+class Animal:  # <-- INH002: has abstract methods but doesn't use ABC
+    @abstractmethod
+    def speak(self) -> str: ...
+```
+
+### Fix
+
+```python
+from abc import ABC, abstractmethod
+
+class Animal(ABC):
+    @abstractmethod
+    def speak(self) -> str: ...
+```
+
+---
+
+## Code Range Allocation
+
+| Range | Category | Status |
+|---|---|---|
+| INH0xx | Inheritance restriction rules | Active |
+| INH1xx | ABC purity checks | Active |
+| INH2xx | Reserved | -- |

--- a/docs/flake8-plugin-contract.md
+++ b/docs/flake8-plugin-contract.md
@@ -1,0 +1,90 @@
+# Flake8 Plugin Contract
+
+How flake8 discovers, loads, and invokes `flake8-inheritance`.
+
+## Discovery
+
+Flake8 finds plugins through Python entry points. The relevant
+configuration in `pyproject.toml`:
+
+```toml
+[project.entry-points."flake8.extension"]
+INH = "flake8_inheritance.checker:InheritanceChecker"
+```
+
+The entry-point **key** (`INH`) determines which error codes the plugin
+owns. Flake8 routes codes starting with `INH` to this checker.
+
+## Plugin Class Requirements
+
+An AST checker plugin must expose:
+
+### Class Attributes
+
+| Attribute | Type | Purpose |
+|---|---|---|
+| `name` | `str` | Human-readable plugin name shown in `flake8 --version` |
+| `version` | `str` | Plugin version shown in `flake8 --version` |
+
+### Constructor
+
+```python
+def __init__(self, tree: ast.AST) -> None:
+```
+
+Flake8 calls the constructor once per file, passing the parsed AST. The
+checker stores the tree for later traversal in `run()`.
+
+### run()
+
+```python
+def run(self) -> Generator[tuple[int, int, str, type], None, None]:
+```
+
+Called once per file after construction. Must yield zero or more tuples:
+
+| Index | Type | Description |
+|---|---|---|
+| 0 | `int` | Line number (1-based) |
+| 1 | `int` | Column offset (0-based) |
+| 2 | `str` | Message including the error code, e.g. `"INH001 ..."` |
+| 3 | `type` | The checker class itself (`InheritanceChecker`) |
+
+### Optional: Options
+
+Plugins may participate in flake8's option system:
+
+```python
+@classmethod
+def add_options(cls, parser: OptionManager) -> None:
+    """Register plugin-specific CLI/config options."""
+
+@classmethod
+def parse_options(cls, options: Namespace) -> None:
+    """Receive parsed option values. Store on the class for run() to use."""
+```
+
+These are **class methods** called once at startup, before any file is
+processed. `parse_options` is called after `add_options` and receives the
+resolved `argparse.Namespace`.
+
+## Lifecycle Summary
+
+```text
+flake8 startup
+  ├── discover entry points
+  ├── call add_options(parser)      [if defined]
+  ├── parse CLI + config
+  └── call parse_options(options)   [if defined]
+
+for each file:
+  ├── parse file -> ast.Module
+  ├── checker = InheritanceChecker(tree)
+  └── for (line, col, msg, cls) in checker.run():
+        report diagnostic
+```
+
+## References
+
+- [Flake8 docs: writing plugins](https://flake8.pycqa.org/en/latest/plugin-development/)
+- [ADR-0008](../doc/adr/0008-use-flake8-ast-checker-plugin-architecture.md)


### PR DESCRIPTION
Create internal documentation following the AI Zealotry pattern:
- docs/README.md: index of available documentation
- docs/architecture.md: module responsibilities, data flow, design principles
- docs/flake8-plugin-contract.md: flake8 plugin API contract details
- docs/error-codes.md: INH001/INH002 reference with triggering and fix examples

https://claude.ai/code/session_01VBnWLaTeL7TEqgodRjtZYS