### PR TITLE
Add ErrorCode frozen dataclass with INH001 and INH002 definitions (TDD)

### DIFF
--- a/src/flake8_inheritance/codes.py
+++ b/src/flake8_inheritance/codes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Final
 
 
 @dataclass(frozen=True)
@@ -17,12 +18,12 @@ class ErrorCode:
         return f"{self.code} {self.message.format(**kwargs)}"
 
 
-INH001 = ErrorCode(
+INH001: Final[ErrorCode] = ErrorCode(
     code="INH001",
     message="Inheritance from internal class '{base}' is not allowed (use composition instead)",
 )
 
-INH002 = ErrorCode(
+INH002: Final[ErrorCode] = ErrorCode(
     code="INH002",
     message=(
         "Abstract base class '{cls}' contains concrete method "

--- a/src/flake8_inheritance/codes.py
+++ b/src/flake8_inheritance/codes.py
@@ -1,3 +1,31 @@
 """Error code definitions for the flake8-inheritance plugin."""
 
 from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ErrorCode:
+    """A single flake8 error code with a formattable message template."""
+
+    code: str
+    message: str
+
+    def format(self, **kwargs: str) -> str:
+        """Return the full error string with the code prefix and formatted message."""
+        return f"{self.code} {self.message.format(**kwargs)}"
+
+
+INH001 = ErrorCode(
+    code="INH001",
+    message="Inheritance from internal class '{base}' is not allowed (use composition instead)",
+)
+
+INH002 = ErrorCode(
+    code="INH002",
+    message=(
+        "Abstract base class '{cls}' contains concrete method "
+        "'{method}' (ABCs should only define abstract methods)"
+    ),
+)

--- a/tests/test_codes.py
+++ b/tests/test_codes.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import dataclasses
 
+import pytest
+
 from flake8_inheritance.codes import INH001, INH002, ErrorCode
 
 
@@ -15,13 +17,8 @@ class TestErrorCodeImmutability:
         assert dataclasses.fields(ErrorCode)  # has fields
         # Frozen dataclasses raise FrozenInstanceError on attribute assignment
         code = ErrorCode(code="TST001", message="test {x}")
-        try:
+        with pytest.raises(dataclasses.FrozenInstanceError):
             code.code = "TST002"  # type: ignore[misc]
-        except dataclasses.FrozenInstanceError:
-            pass
-        else:
-            msg = "ErrorCode should be frozen"
-            raise AssertionError(msg)
 
 
 class TestINH001:

--- a/tests/test_codes.py
+++ b/tests/test_codes.py
@@ -1,0 +1,51 @@
+"""Tests for error code definitions."""
+
+from __future__ import annotations
+
+import dataclasses
+
+from flake8_inheritance.codes import INH001, INH002, ErrorCode
+
+
+class TestErrorCodeImmutability:
+    """ErrorCode instances must be frozen (immutable)."""
+
+    def test_error_code_is_frozen_dataclass(self) -> None:
+        assert dataclasses.is_dataclass(ErrorCode)
+        assert dataclasses.fields(ErrorCode)  # has fields
+        # Frozen dataclasses raise FrozenInstanceError on attribute assignment
+        code = ErrorCode(code="TST001", message="test {x}")
+        try:
+            code.code = "TST002"  # type: ignore[misc]
+        except dataclasses.FrozenInstanceError:
+            pass
+        else:
+            msg = "ErrorCode should be frozen"
+            raise AssertionError(msg)
+
+
+class TestINH001:
+    """INH001: inheritance from internal class."""
+
+    def test_code_value(self) -> None:
+        assert INH001.code == "INH001"
+
+    def test_format(self) -> None:
+        result = INH001.format(base="Foo")
+        assert result == (
+            "INH001 Inheritance from internal class 'Foo' is not allowed (use composition instead)"
+        )
+
+
+class TestINH002:
+    """INH002: ABC with concrete method."""
+
+    def test_code_value(self) -> None:
+        assert INH002.code == "INH002"
+
+    def test_format(self) -> None:
+        result = INH002.format(cls="MyABC", method="do_thing")
+        assert result == (
+            "INH002 Abstract base class 'MyABC' contains concrete method "
+            "'do_thing' (ABCs should only define abstract methods)"
+        )


### PR DESCRIPTION
Define a frozen ErrorCode dataclass with code, message, and format() method.
Add INH001 (inheritance from internal class) and INH002 (ABC with concrete
method) error codes with message templates. Tests verify immutability and
format output.

https://claude.ai/code/session_01ABCpxKJK7nrh6QRLGFQeJa