### PR TITLE
Add ADR for import classification strategy

### DIFF
--- a/doc/adr/0010-classify-imports-using-sys-stdlib-module-names-and-project-packages-config.md
+++ b/doc/adr/0010-classify-imports-using-sys-stdlib-module-names-and-project-packages-config.md
@@ -32,8 +32,9 @@ relative imports, record the module name as the sentinel value
   (`same_file`), and unresolved cases (`unknown`) in a consistent way.
 - Relative imports are explicitly tracked with `__relative__`, allowing later
   resolution logic to treat them separately.
-- The approach requires Python 3.10+ for `sys.stdlib_module_names`, which
-  matches the project's minimum supported version.
+- The approach relies on `sys.stdlib_module_names`, available in Python 3.10+,
+  and is fully compatible with the project's minimum supported Python version
+  (3.11+).
 
 ## Alternatives considered
 

--- a/doc/adr/0010-classify-imports-using-sys-stdlib-module-names-and-project-packages-config.md
+++ b/doc/adr/0010-classify-imports-using-sys-stdlib-module-names-and-project-packages-config.md
@@ -1,0 +1,46 @@
+# 10: Classify imports using sys.stdlib_module_names and project-packages config
+
+Date: 2026-02-09
+Status: Accepted
+
+## Context
+
+The import analysis engine needs a consistent way to classify imported
+modules so it can reason about composition rules. The classification must
+distinguish standard library modules from third-party dependencies and local
+project modules, while also handling relative imports and edge cases where
+the origin is not clear at analysis time. Maintaining a hardcoded list of
+stdlib modules is brittle and error-prone across Python versions. We also
+need a deterministic representation for relative imports so we can defer
+resolution to later stages while still recording their presence.
+
+## Decision
+
+Classify imports into five categories: `internal`, `external`, `stdlib`,
+`same_file`, and `unknown`. Use `sys.stdlib_module_names` (available since
+Python 3.10) to identify standard library modules, and use the
+project-packages configuration to recognize third-party dependencies. For
+relative imports, record the module name as the sentinel value
+`__relative__`.
+
+## Consequences
+
+- The stdlib classification stays aligned with the running Python version
+  without maintaining a custom list.
+- The analyzer can distinguish local modules (`internal`), dependencies
+  (`external`), standard library (`stdlib`), imports from the same module
+  (`same_file`), and unresolved cases (`unknown`) in a consistent way.
+- Relative imports are explicitly tracked with `__relative__`, allowing later
+  resolution logic to treat them separately.
+- The approach requires Python 3.10+ for `sys.stdlib_module_names`, which
+  matches the project's minimum supported version.
+
+## Alternatives considered
+
+- Maintain a hardcoded stdlib list: rejected due to ongoing maintenance and
+  version drift.
+- Use `importlib.util.find_spec` for classification: rejected because it can
+  execute import hooks and is slow or unreliable for non-installed modules
+  during static analysis.
+- Encode relative imports with empty module names: rejected because it is
+  ambiguous and harder to distinguish from missing data.

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -9,3 +9,4 @@
 - 0007. [Use composition-over-inheritance as the core design principle](0007-use-composition-over-inheritance-as-the-core-design-principle.md) — Accepted (2026-02-07)
 - 0008. [Use flake8 AST checker plugin architecture](0008-use-flake8-ast-checker-plugin-architecture.md) — Accepted (2026-02-07)
 - 0009. [Use uv for project and dependency management](0009-use-uv-for-project-and-dependency-management.md) — Accepted (2026-02-07)
+- 0010. [Classify imports using sys.stdlib_module_names and project-packages config](0010-classify-imports-using-sys-stdlib-module-names-and-project-packages-config.md) — Accepted (2026-02-09)


### PR DESCRIPTION
### Motivation
- The import analysis engine needs a deterministic way to classify imports so it can reason about composition rules and distinguish standard library, third-party, local, same-file, and unresolved imports.
- The decision avoids brittle, hardcoded stdlib lists by relying on `sys.stdlib_module_names` and requires a clear representation for relative imports using the sentinel `__relative__`.

### Description
- Add ADR file `doc/adr/0010-classify-imports-using-sys-stdlib-module-names-and-project-packages-config.md` documenting the import classification strategy and rationale.
- Define five import categories: `internal`, `external`, `stdlib`, `same_file`, and `unknown`, and prescribe using `sys.stdlib_module_names` plus the `project-packages` configuration for classification.
- Specify representing relative imports with the sentinel `__relative__` and record alternatives considered (e.g., hardcoded stdlib lists and `importlib.util.find_spec`) and their downsides.

### Testing
- Ran `uv run pre-commit run --all-files` and all checks passed.
- Ran `uv run pytest` and the suite completed successfully (`8 passed`).
- Ran `decree list` to verify the ADR is registered and the new ADR appears in the list.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69892791ca6c8326b0582c943d5228db)