### PR TITLE
Add ImportTracker with import mapping and classification and tests

### DIFF
--- a/src/flake8_inheritance/visitors.py
+++ b/src/flake8_inheritance/visitors.py
@@ -1,3 +1,52 @@
 """AST visitors for inheritance rule checks."""
 
 from __future__ import annotations
+
+import ast
+import sys
+from typing import Final
+
+RELATIVE_SENTINEL: Final[str] = "__relative__"
+
+
+class ImportTracker(ast.NodeVisitor):
+    """Collect import statements and classify their origin."""
+
+    def __init__(self, project_package: str | None = None) -> None:
+        """Initialize tracker with an optional project package name."""
+        self.imports: dict[str, str] = {}
+        self._project_package = project_package
+
+    def visit_Import(self, node: ast.Import) -> None:  # noqa: N802
+        """Record modules imported with ``import ...`` statements."""
+        for alias in node.names:
+            top_level = alias.name.split(".")[0]
+            local_name = alias.asname or top_level
+            self.imports[local_name] = top_level
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:  # noqa: N802
+        """Record modules imported with ``from ... import ...`` statements."""
+        if node.level > 0:
+            source_module = RELATIVE_SENTINEL
+        elif node.module:
+            source_module = node.module.split(".")[0]
+        else:
+            source_module = ""
+
+        for alias in node.names:
+            local_name = alias.asname or alias.name
+            self.imports[local_name] = source_module
+
+    def classify(self, local_name: str) -> str:
+        """Return classification for a local import name."""
+        if local_name not in self.imports:
+            return "unknown"
+
+        source_module = self.imports[local_name]
+        if source_module == RELATIVE_SENTINEL:
+            return "same_file"
+        if source_module in sys.stdlib_module_names:
+            return "stdlib"
+        if self._project_package and source_module == self._project_package:
+            return "internal"
+        return "external"

--- a/src/flake8_inheritance/visitors.py
+++ b/src/flake8_inheritance/visitors.py
@@ -45,8 +45,8 @@ class ImportTracker(ast.NodeVisitor):
         source_module = self.imports[local_name]
         if source_module == RELATIVE_SENTINEL:
             return "same_file"
-        if source_module in sys.stdlib_module_names:
-            return "stdlib"
         if self._project_package and source_module == self._project_package:
             return "internal"
+        if source_module in sys.stdlib_module_names:
+            return "stdlib"
         return "external"

--- a/src/flake8_inheritance/visitors.py
+++ b/src/flake8_inheritance/visitors.py
@@ -43,6 +43,8 @@ class ImportTracker(ast.NodeVisitor):
             return "unknown"
 
         source_module = self.imports[local_name]
+        if not source_module:
+            return "unknown"
         if source_module == RELATIVE_SENTINEL:
             return "same_file"
         if self._project_package and source_module == self._project_package:

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import ast
 
-from flake8_inheritance.visitors import ImportTracker
+from flake8_inheritance.visitors import RELATIVE_SENTINEL, ImportTracker
 
 
 def track_imports(source: str) -> ImportTracker:
@@ -37,12 +37,12 @@ def test_from_import_with_alias_tracks_alias_name() -> None:
 
 def test_relative_import_records_relative_sentinel() -> None:
     tracker = track_imports("from .models import Base")
-    assert tracker.imports == {"Base": "__relative__"}
+    assert tracker.imports == {"Base": RELATIVE_SENTINEL}
 
 
 def test_relative_import_without_module_records_relative_sentinel() -> None:
     tracker = track_imports("from . import utils")
-    assert tracker.imports == {"utils": "__relative__"}
+    assert tracker.imports == {"utils": RELATIVE_SENTINEL}
 
 
 def test_classification_categories() -> None:

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import ast
 
+import pytest
+
 from flake8_inheritance.visitors import RELATIVE_SENTINEL, ImportTracker
 
 
@@ -15,34 +17,20 @@ def track_imports(source: str) -> ImportTracker:
     return tracker
 
 
-def test_import_statement_maps_module_name() -> None:
-    tracker = track_imports("import foo")
-    assert tracker.imports == {"foo": "foo"}
-
-
-def test_import_statement_with_alias_tracks_local_name() -> None:
-    tracker = track_imports("import foo.bar as baz")
-    assert tracker.imports == {"baz": "foo"}
-
-
-def test_from_import_maps_to_top_level_package() -> None:
-    tracker = track_imports("from foo.bar import Baz")
-    assert tracker.imports == {"Baz": "foo"}
-
-
-def test_from_import_with_alias_tracks_alias_name() -> None:
-    tracker = track_imports("from foo.bar import Baz as B")
-    assert tracker.imports == {"B": "foo"}
-
-
-def test_relative_import_records_relative_sentinel() -> None:
-    tracker = track_imports("from .models import Base")
-    assert tracker.imports == {"Base": RELATIVE_SENTINEL}
-
-
-def test_relative_import_without_module_records_relative_sentinel() -> None:
-    tracker = track_imports("from . import utils")
-    assert tracker.imports == {"utils": RELATIVE_SENTINEL}
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("import foo", {"foo": "foo"}),
+        ("import foo.bar as baz", {"baz": "foo"}),
+        ("from foo.bar import Baz", {"Baz": "foo"}),
+        ("from foo.bar import Baz as B", {"B": "foo"}),
+        ("from .models import Base", {"Base": RELATIVE_SENTINEL}),
+        ("from . import utils", {"utils": RELATIVE_SENTINEL}),
+    ],
+)
+def test_import_mapping(source: str, expected: dict[str, str]) -> None:
+    tracker = track_imports(source)
+    assert tracker.imports == expected
 
 
 def test_classification_categories() -> None:

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -41,14 +41,12 @@ def test_relative_import_without_module_records_relative_sentinel() -> None:
 
 
 def test_classification_categories() -> None:
-    source = "\n".join(
-        [
-            "import sys",
-            "import requests",
-            "import internal_pkg.utils",
-            "from . import local_mod",
-        ]
-    )
+    source = """\
+import sys
+import requests
+import internal_pkg.utils
+from . import local_mod
+"""
     tree = ast.parse(source)
     tracker = ImportTracker(project_package="internal_pkg")
     tracker.visit(tree)

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -56,3 +56,10 @@ from . import local_mod
     assert tracker.classify("internal_pkg") == "internal"
     assert tracker.classify("local_mod") == "same_file"
     assert tracker.classify("missing") == "unknown"
+
+
+def test_project_package_overrides_stdlib_name() -> None:
+    tracker = ImportTracker(project_package="email")
+    tracker.visit(ast.parse("import email"))
+
+    assert tracker.classify("email") == "internal"

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -20,6 +20,11 @@ def test_import_statement_maps_module_name() -> None:
     assert tracker.imports == {"foo": "foo"}
 
 
+def test_import_statement_with_alias_tracks_local_name() -> None:
+    tracker = track_imports("import foo.bar as baz")
+    assert tracker.imports == {"baz": "foo"}
+
+
 def test_from_import_maps_to_top_level_package() -> None:
     tracker = track_imports("from foo.bar import Baz")
     assert tracker.imports == {"Baz": "foo"}

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -63,3 +63,11 @@ def test_project_package_overrides_stdlib_name() -> None:
     tracker.visit(ast.parse("import email"))
 
     assert tracker.classify("email") == "internal"
+
+
+def test_empty_import_from_module_classifies_unknown() -> None:
+    tracker = ImportTracker()
+    node = ast.ImportFrom(module=None, names=[ast.alias(name="Thing")], level=0)
+    tracker.visit_ImportFrom(node)
+
+    assert tracker.classify("Thing") == "unknown"

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -1,0 +1,60 @@
+"""Tests for AST visitors and import tracking."""
+
+from __future__ import annotations
+
+import ast
+
+from flake8_inheritance.visitors import ImportTracker
+
+
+def track_imports(source: str) -> ImportTracker:
+    """Parse source code and return a populated ImportTracker."""
+    tree = ast.parse(source)
+    tracker = ImportTracker()
+    tracker.visit(tree)
+    return tracker
+
+
+def test_import_statement_maps_module_name() -> None:
+    tracker = track_imports("import foo")
+    assert tracker.imports == {"foo": "foo"}
+
+
+def test_from_import_maps_to_top_level_package() -> None:
+    tracker = track_imports("from foo.bar import Baz")
+    assert tracker.imports == {"Baz": "foo"}
+
+
+def test_from_import_with_alias_tracks_alias_name() -> None:
+    tracker = track_imports("from foo.bar import Baz as B")
+    assert tracker.imports == {"B": "foo"}
+
+
+def test_relative_import_records_relative_sentinel() -> None:
+    tracker = track_imports("from .models import Base")
+    assert tracker.imports == {"Base": "__relative__"}
+
+
+def test_relative_import_without_module_records_relative_sentinel() -> None:
+    tracker = track_imports("from . import utils")
+    assert tracker.imports == {"utils": "__relative__"}
+
+
+def test_classification_categories() -> None:
+    source = "\n".join(
+        [
+            "import sys",
+            "import requests",
+            "import internal_pkg.utils",
+            "from . import local_mod",
+        ]
+    )
+    tree = ast.parse(source)
+    tracker = ImportTracker(project_package="internal_pkg")
+    tracker.visit(tree)
+
+    assert tracker.classify("sys") == "stdlib"
+    assert tracker.classify("requests") == "external"
+    assert tracker.classify("internal_pkg") == "internal"
+    assert tracker.classify("local_mod") == "same_file"
+    assert tracker.classify("missing") == "unknown"


### PR DESCRIPTION
### Motivation
- Provide standalone import-tracking and classification logic for the core analysis engine so imports can be classified as stdlib, external, internal, same-file, or unknown.

### Description
- Add `ImportTracker` in `src/flake8_inheritance/visitors.py` that visits `ast.Import` and `ast.ImportFrom` nodes and records a mapping of local names to source modules, with `RELATIVE_SENTINEL` for relative imports.
- Implement `classify(local_name)` which uses `sys.stdlib_module_names` and an optional `project_package` parameter to return the correct category (`stdlib`, `external`, `internal`, `same_file`, `unknown`).
- Ensure alias handling and top-level package extraction are correct for both `import foo` and `from foo.bar import Baz as B` cases.
- Add `tests/test_visitors.py` with tests for import mapping, aliasing, relative imports, and all classification categories.

### Testing
- Ran `uv run pre-commit run --all-files`, which passed all hooks.
- Ran `uv run pytest tests/test_visitors.py`, which passed (6 tests).
- Ran full test suite with `uv run pytest`, which passed (14 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69892f1db5348326ba3714b6949bea34)