### PR TITLE
Implement INH001: detect internal inheritance (TDD)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ ignore = [
     "D",       # docstring rules relaxed in tests
     "S101",    # assert allowed in tests
     "ANN",     # annotations not required in tests
+    "PLR2004", # magic values fine in test assertions
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ ignore = [
     "D",       # docstring rules relaxed in tests
     "S101",    # assert allowed in tests
     "ANN",     # annotations not required in tests
-    "PLR2004", # magic values fine in test assertions
+
 ]
 
 [tool.mypy]

--- a/src/flake8_inheritance/visitors.py
+++ b/src/flake8_inheritance/visitors.py
@@ -6,6 +6,8 @@ import ast
 import sys
 from typing import Final
 
+from flake8_inheritance.codes import INH001
+
 RELATIVE_SENTINEL: Final[str] = "__relative__"
 
 
@@ -52,3 +54,72 @@ class ImportTracker(ast.NodeVisitor):
         if source_module in sys.stdlib_module_names:
             return "stdlib"
         return "external"
+
+
+def _resolve_base(node: ast.expr) -> str | None:
+    """Resolve a base class node to a dotted name string.
+
+    Returns ``None`` for dynamic bases (e.g. function calls).
+    """
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parts: list[str] = [node.attr]
+        current: ast.expr = node.value
+        while isinstance(current, ast.Attribute):
+            parts.append(current.attr)
+            current = current.value
+        if isinstance(current, ast.Name):
+            parts.append(current.id)
+            return ".".join(reversed(parts))
+    return None
+
+
+class InheritanceVisitor(ast.NodeVisitor):
+    """Detect internal inheritance (INH001).
+
+    Walks ``ast.ClassDef`` nodes and flags base classes that are classified
+    as ``internal`` or ``same_file`` by the provided :class:`ImportTracker`.
+    Also tracks module-level class definitions for same-file detection.
+    """
+
+    def __init__(self, import_tracker: ImportTracker) -> None:
+        """Initialize with a pre-populated import tracker."""
+        self._tracker = import_tracker
+        self._module_classes: set[str] = set()
+        self.errors: list[tuple[int, int, str]] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+        """Process a class definition, checking each base class."""
+        self._module_classes.add(node.name)
+
+        for base in node.bases:
+            base_name = _resolve_base(base)
+            if base_name is None:
+                continue
+
+            # For attribute access (e.g. module.Class), classify the root name
+            root_name = base_name.split(".")[0]
+
+            # Check if it's a class defined in the same file
+            if root_name in self._module_classes and root_name == base_name:
+                self.errors.append(
+                    (
+                        node.lineno,
+                        node.col_offset,
+                        INH001.format(base=base_name),
+                    )
+                )
+                continue
+
+            classification = self._tracker.classify(root_name)
+            if classification in ("internal", "same_file"):
+                self.errors.append(
+                    (
+                        node.lineno,
+                        node.col_offset,
+                        INH001.format(base=base_name),
+                    )
+                )
+
+        self.generic_visit(node)

--- a/src/flake8_inheritance/visitors.py
+++ b/src/flake8_inheritance/visitors.py
@@ -4,11 +4,30 @@ from __future__ import annotations
 
 import ast
 import sys
+from dataclasses import dataclass
 from typing import Final
 
-from flake8_inheritance.codes import INH001
+from flake8_inheritance.codes import INH001, ErrorCode
 
 RELATIVE_SENTINEL: Final[str] = "__relative__"
+
+
+@dataclass(frozen=True)
+class InheritanceError:
+    """A located error produced by the inheritance visitor."""
+
+    line: int
+    col: int
+    code: ErrorCode
+    base_name: str
+
+    def format(self) -> str:
+        """Return the full flake8 error string."""
+        return self.code.format(base=self.base_name)
+
+    def as_flake8_tuple(self) -> tuple[int, int, str, type]:
+        """Return the ``(line, col, message, type)`` tuple flake8 expects."""
+        return (self.line, self.col, self.format(), type(self))
 
 
 class ImportTracker(ast.NodeVisitor):
@@ -60,7 +79,10 @@ def _resolve_base(node: ast.expr) -> str | None:
     """Resolve a base class node to a dotted name string.
 
     Returns ``None`` for dynamic bases (e.g. function calls).
+    Unwraps ``ast.Subscript`` so that ``Base[T]`` resolves to ``Base``.
     """
+    if isinstance(node, ast.Subscript):
+        return _resolve_base(node.value)
     if isinstance(node, ast.Name):
         return node.id
     if isinstance(node, ast.Attribute):
@@ -75,6 +97,16 @@ def _resolve_base(node: ast.expr) -> str | None:
     return None
 
 
+def _collect_module_class_names(tree: ast.AST) -> set[str]:
+    """Pre-scan the module body and return all top-level class names."""
+    names: set[str] = set()
+    if isinstance(tree, ast.Module):
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef):
+                names.add(node.name)
+    return names
+
+
 class InheritanceVisitor(ast.NodeVisitor):
     """Detect internal inheritance (INH001).
 
@@ -83,16 +115,18 @@ class InheritanceVisitor(ast.NodeVisitor):
     Also tracks module-level class definitions for same-file detection.
     """
 
-    def __init__(self, import_tracker: ImportTracker) -> None:
+    def __init__(
+        self,
+        import_tracker: ImportTracker,
+        module_class_names: frozenset[str] = frozenset(),
+    ) -> None:
         """Initialize with a pre-populated import tracker."""
         self._tracker = import_tracker
-        self._module_classes: set[str] = set()
-        self.errors: list[tuple[int, int, str]] = []
+        self._module_classes = module_class_names
+        self.errors: list[InheritanceError] = []
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
         """Process a class definition, checking each base class."""
-        self._module_classes.add(node.name)
-
         for base in node.bases:
             base_name = _resolve_base(base)
             if base_name is None:
@@ -101,13 +135,14 @@ class InheritanceVisitor(ast.NodeVisitor):
             # For attribute access (e.g. module.Class), classify the root name
             root_name = base_name.split(".")[0]
 
-            # Check if it's a class defined in the same file
+            # Check if it's a class defined at module level in the same file
             if root_name in self._module_classes and root_name == base_name:
                 self.errors.append(
-                    (
-                        node.lineno,
-                        node.col_offset,
-                        INH001.format(base=base_name),
+                    InheritanceError(
+                        line=node.lineno,
+                        col=node.col_offset,
+                        code=INH001,
+                        base_name=base_name,
                     )
                 )
                 continue
@@ -115,10 +150,11 @@ class InheritanceVisitor(ast.NodeVisitor):
             classification = self._tracker.classify(root_name)
             if classification in ("internal", "same_file"):
                 self.errors.append(
-                    (
-                        node.lineno,
-                        node.col_offset,
-                        INH001.format(base=base_name),
+                    InheritanceError(
+                        line=node.lineno,
+                        col=node.col_offset,
+                        code=INH001,
+                        base_name=base_name,
                     )
                 )
 

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -6,7 +6,11 @@ import ast
 
 import pytest
 
-from flake8_inheritance.visitors import RELATIVE_SENTINEL, ImportTracker
+from flake8_inheritance.visitors import (
+    RELATIVE_SENTINEL,
+    ImportTracker,
+    InheritanceVisitor,
+)
 
 
 def track_imports(source: str) -> ImportTracker:
@@ -64,3 +68,216 @@ def test_empty_import_from_module_classifies_unknown() -> None:
     tracker.visit_ImportFrom(node)
 
     assert tracker.classify("Thing") == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Helpers for INH001 tests
+# ---------------------------------------------------------------------------
+
+
+def collect_errors(
+    source: str,
+    project_package: str | None = None,
+) -> list[tuple[int, int, str]]:
+    """Parse source, run ImportTracker + InheritanceVisitor, return errors."""
+    tree = ast.parse(source)
+    tracker = ImportTracker(project_package=project_package)
+    tracker.visit(tree)
+    visitor = InheritanceVisitor(import_tracker=tracker)
+    visitor.visit(tree)
+    return visitor.errors
+
+
+# ---------------------------------------------------------------------------
+# INH001 — detect internal inheritance
+# ---------------------------------------------------------------------------
+
+
+class TestINH001SameFileInheritance:
+    """Classes inheriting from other classes defined in the same file."""
+
+    def test_same_file_class_flagged(self) -> None:
+        source = """\
+class Base:
+    pass
+
+class Child(Base):
+    pass
+"""
+        errors = collect_errors(source)
+        assert len(errors) == 1
+        line, col, msg = errors[0]
+        assert line == 4
+        assert col == 0
+        assert "INH001" in msg
+        assert "Base" in msg
+
+    def test_multiple_same_file_bases_flagged(self) -> None:
+        source = """\
+class A:
+    pass
+
+class B:
+    pass
+
+class C(A, B):
+    pass
+"""
+        errors = collect_errors(source)
+        assert len(errors) == 2
+
+
+class TestINH001RelativeImportInheritance:
+    """Classes inheriting from relatively imported classes."""
+
+    def test_relative_import_flagged(self) -> None:
+        source = """\
+from .models import Base
+
+class Child(Base):
+    pass
+"""
+        errors = collect_errors(source)
+        assert len(errors) == 1
+        assert "INH001" in errors[0][2]
+        assert "Base" in errors[0][2]
+
+    def test_relative_import_dot_only_flagged(self) -> None:
+        source = """\
+from . import Base
+
+class Child(Base):
+    pass
+"""
+        errors = collect_errors(source)
+        assert len(errors) == 1
+
+
+class TestINH001ProjectPackageInheritance:
+    """Classes inheriting from configured project package classes."""
+
+    def test_project_package_flagged(self) -> None:
+        source = """\
+from myproject.models import Base
+
+class Child(Base):
+    pass
+"""
+        errors = collect_errors(source, project_package="myproject")
+        assert len(errors) == 1
+        assert "INH001" in errors[0][2]
+        assert "Base" in errors[0][2]
+
+
+class TestINH001AllowedBases:
+    """Inheritance from stdlib and third-party classes should not be flagged."""
+
+    def test_stdlib_base_allowed(self) -> None:
+        source = """\
+from collections import OrderedDict
+
+class MyDict(OrderedDict):
+    pass
+"""
+        errors = collect_errors(source)
+        assert errors == []
+
+    def test_third_party_base_allowed(self) -> None:
+        source = """\
+from pydantic import BaseModel
+
+class User(BaseModel):
+    pass
+"""
+        errors = collect_errors(source)
+        assert errors == []
+
+    def test_unrecognized_absolute_import_not_flagged(self) -> None:
+        source = """\
+from somepackage import Base
+
+class Child(Base):
+    pass
+"""
+        errors = collect_errors(source)  # no project_package configured
+        assert errors == []
+
+
+class TestINH001DynamicBases:
+    """Dynamic base classes should be silently skipped."""
+
+    def test_dynamic_base_skipped(self) -> None:
+        source = """\
+class Child(get_base()):
+    pass
+"""
+        errors = collect_errors(source)
+        assert errors == []
+
+    def test_dynamic_base_with_regular_base(self) -> None:
+        source = """\
+from .models import Base
+
+class Child(Base, get_mixin()):
+    pass
+"""
+        errors = collect_errors(source)
+        assert len(errors) == 1
+        assert "Base" in errors[0][2]
+
+
+class TestINH001AttributeBases:
+    """ast.Attribute base classes (e.g., module.Class) resolved correctly."""
+
+    def test_attribute_base_from_project_package(self) -> None:
+        source = """\
+import myproject.models
+
+class Child(myproject.models.Base):
+    pass
+"""
+        errors = collect_errors(source, project_package="myproject")
+        assert len(errors) == 1
+        assert "INH001" in errors[0][2]
+        assert "myproject.models.Base" in errors[0][2]
+
+    def test_attribute_base_from_stdlib(self) -> None:
+        source = """\
+import collections
+
+class MyDict(collections.OrderedDict):
+    pass
+"""
+        errors = collect_errors(source)
+        assert errors == []
+
+    def test_attribute_base_from_third_party(self) -> None:
+        source = """\
+import flask
+
+class MyApp(flask.Flask):
+    pass
+"""
+        errors = collect_errors(source)
+        assert errors == []
+
+
+class TestINH001NoFalsePositives:
+    """Edge cases that should not produce errors."""
+
+    def test_class_with_no_bases(self) -> None:
+        source = """\
+class Standalone:
+    pass
+"""
+        errors = collect_errors(source)
+        assert errors == []
+
+    def test_class_inheriting_from_unknown_name(self) -> None:
+        """A name that was never imported and not defined in file."""
+        source = """\
+class Child(SomeUnknownBase):
+    pass
+"""
+        errors = collect_errors(source)
+        assert errors == []

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -104,10 +104,11 @@ class Base:
 class Child(Base):
     pass
 """
+        child_line = 4
         errors = collect_errors(source)
         assert len(errors) == 1
         line, col, msg = errors[0]
-        assert line == 4
+        assert line == child_line
         assert col == 0
         assert "INH001" in msg
         assert "Base" in msg
@@ -123,8 +124,9 @@ class B:
 class C(A, B):
     pass
 """
+        expected_error_count = 2
         errors = collect_errors(source)
-        assert len(errors) == 2
+        assert len(errors) == expected_error_count
 
 
 class TestINH001RelativeImportInheritance:

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -6,10 +6,13 @@ import ast
 
 import pytest
 
+from flake8_inheritance.codes import INH001
 from flake8_inheritance.visitors import (
     RELATIVE_SENTINEL,
     ImportTracker,
+    InheritanceError,
     InheritanceVisitor,
+    _collect_module_class_names,
 )
 
 
@@ -78,14 +81,23 @@ def test_empty_import_from_module_classifies_unknown() -> None:
 def collect_errors(
     source: str,
     project_package: str | None = None,
-) -> list[tuple[int, int, str]]:
+) -> list[InheritanceError]:
     """Parse source, run ImportTracker + InheritanceVisitor, return errors."""
     tree = ast.parse(source)
     tracker = ImportTracker(project_package=project_package)
     tracker.visit(tree)
-    visitor = InheritanceVisitor(import_tracker=tracker)
+    module_classes = _collect_module_class_names(tree)
+    visitor = InheritanceVisitor(
+        import_tracker=tracker,
+        module_class_names=frozenset(module_classes),
+    )
     visitor.visit(tree)
     return visitor.errors
+
+
+def flagged_bases(errors: list[InheritanceError]) -> list[str]:
+    """Return just the base names from a list of errors."""
+    return [e.base_name for e in errors]
 
 
 # ---------------------------------------------------------------------------
@@ -106,12 +118,9 @@ class Child(Base):
 """
         child_line = 4
         errors = collect_errors(source)
-        assert len(errors) == 1
-        line, col, msg = errors[0]
-        assert line == child_line
-        assert col == 0
-        assert "INH001" in msg
-        assert "Base" in msg
+        assert flagged_bases(errors) == ["Base"]
+        assert errors[0].code is INH001
+        assert errors[0].line == child_line
 
     def test_multiple_same_file_bases_flagged(self) -> None:
         source = """\
@@ -124,9 +133,33 @@ class B:
 class C(A, B):
     pass
 """
-        expected_error_count = 2
         errors = collect_errors(source)
-        assert len(errors) == expected_error_count
+        assert flagged_bases(errors) == ["A", "B"]
+
+    def test_forward_declaration_flagged(self) -> None:
+        """Base defined after child should still be flagged."""
+        source = """\
+class Child(Base):
+    pass
+
+class Base:
+    pass
+"""
+        errors = collect_errors(source)
+        assert flagged_bases(errors) == ["Base"]
+
+    def test_nested_class_not_treated_as_module_level(self) -> None:
+        """A class nested inside another should not trigger same-file detection."""
+        source = """\
+class Outer:
+    class Inner:
+        pass
+
+class Other(Inner):
+    pass
+"""
+        errors = collect_errors(source)
+        assert errors == []
 
 
 class TestINH001RelativeImportInheritance:
@@ -140,9 +173,8 @@ class Child(Base):
     pass
 """
         errors = collect_errors(source)
-        assert len(errors) == 1
-        assert "INH001" in errors[0][2]
-        assert "Base" in errors[0][2]
+        assert flagged_bases(errors) == ["Base"]
+        assert errors[0].code is INH001
 
     def test_relative_import_dot_only_flagged(self) -> None:
         source = """\
@@ -152,7 +184,7 @@ class Child(Base):
     pass
 """
         errors = collect_errors(source)
-        assert len(errors) == 1
+        assert flagged_bases(errors) == ["Base"]
 
 
 class TestINH001ProjectPackageInheritance:
@@ -166,9 +198,8 @@ class Child(Base):
     pass
 """
         errors = collect_errors(source, project_package="myproject")
-        assert len(errors) == 1
-        assert "INH001" in errors[0][2]
-        assert "Base" in errors[0][2]
+        assert flagged_bases(errors) == ["Base"]
+        assert errors[0].code is INH001
 
 
 class TestINH001AllowedBases:
@@ -181,8 +212,7 @@ from collections import OrderedDict
 class MyDict(OrderedDict):
     pass
 """
-        errors = collect_errors(source)
-        assert errors == []
+        assert collect_errors(source) == []
 
     def test_third_party_base_allowed(self) -> None:
         source = """\
@@ -191,8 +221,7 @@ from pydantic import BaseModel
 class User(BaseModel):
     pass
 """
-        errors = collect_errors(source)
-        assert errors == []
+        assert collect_errors(source) == []
 
     def test_unrecognized_absolute_import_not_flagged(self) -> None:
         source = """\
@@ -201,8 +230,7 @@ from somepackage import Base
 class Child(Base):
     pass
 """
-        errors = collect_errors(source)  # no project_package configured
-        assert errors == []
+        assert collect_errors(source) == []  # no project_package configured
 
 
 class TestINH001DynamicBases:
@@ -213,8 +241,7 @@ class TestINH001DynamicBases:
 class Child(get_base()):
     pass
 """
-        errors = collect_errors(source)
-        assert errors == []
+        assert collect_errors(source) == []
 
     def test_dynamic_base_with_regular_base(self) -> None:
         source = """\
@@ -224,8 +251,7 @@ class Child(Base, get_mixin()):
     pass
 """
         errors = collect_errors(source)
-        assert len(errors) == 1
-        assert "Base" in errors[0][2]
+        assert flagged_bases(errors) == ["Base"]
 
 
 class TestINH001AttributeBases:
@@ -239,9 +265,8 @@ class Child(myproject.models.Base):
     pass
 """
         errors = collect_errors(source, project_package="myproject")
-        assert len(errors) == 1
-        assert "INH001" in errors[0][2]
-        assert "myproject.models.Base" in errors[0][2]
+        assert flagged_bases(errors) == ["myproject.models.Base"]
+        assert errors[0].code is INH001
 
     def test_attribute_base_from_stdlib(self) -> None:
         source = """\
@@ -250,8 +275,7 @@ import collections
 class MyDict(collections.OrderedDict):
     pass
 """
-        errors = collect_errors(source)
-        assert errors == []
+        assert collect_errors(source) == []
 
     def test_attribute_base_from_third_party(self) -> None:
         source = """\
@@ -260,8 +284,58 @@ import flask
 class MyApp(flask.Flask):
     pass
 """
+        assert collect_errors(source) == []
+
+
+class TestINH001SubscriptBases:
+    """Generic base classes like Base[T] should be unwrapped and checked."""
+
+    def test_subscript_same_file_flagged(self) -> None:
+        source = """\
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Base(Generic[T]):
+    pass
+
+class Child(Base[int]):
+    pass
+"""
         errors = collect_errors(source)
-        assert errors == []
+        assert flagged_bases(errors) == ["Base"]
+
+    def test_subscript_relative_import_flagged(self) -> None:
+        source = """\
+from .models import Base
+
+class Child(Base[int]):
+    pass
+"""
+        errors = collect_errors(source)
+        assert flagged_bases(errors) == ["Base"]
+
+    def test_subscript_attribute_flagged(self) -> None:
+        source = """\
+import myproject.models
+
+class Child(myproject.models.Base[int]):
+    pass
+"""
+        errors = collect_errors(source, project_package="myproject")
+        assert flagged_bases(errors) == ["myproject.models.Base"]
+
+    def test_subscript_stdlib_allowed(self) -> None:
+        source = """\
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class MyClass(Generic[T]):
+    pass
+"""
+        # Generic is stdlib, should not be flagged
+        assert collect_errors(source) == []
 
 
 class TestINH001NoFalsePositives:
@@ -272,8 +346,7 @@ class TestINH001NoFalsePositives:
 class Standalone:
     pass
 """
-        errors = collect_errors(source)
-        assert errors == []
+        assert collect_errors(source) == []
 
     def test_class_inheriting_from_unknown_name(self) -> None:
         """A name that was never imported and not defined in file."""
@@ -281,5 +354,4 @@ class Standalone:
 class Child(SomeUnknownBase):
     pass
 """
-        errors = collect_errors(source)
-        assert errors == []
+        assert collect_errors(source) == []


### PR DESCRIPTION
Add InheritanceVisitor that walks ClassDef nodes and flags base classes
classified as internal (project package) or same-file (defined in module
or relatively imported). Handles ast.Name, ast.Attribute, and silently
skips dynamic bases.

https://claude.ai/code/session_01DigkFwhTEnAPDp4gTue8F6