### PR TITLE
Implement INH002: detect impure ABCs (TDD)

### DIFF
--- a/src/flake8_inheritance/visitors.py
+++ b/src/flake8_inheritance/visitors.py
@@ -14,26 +14,42 @@ RELATIVE_SENTINEL: Final[str] = "__relative__"
 
 @dataclass(frozen=True)
 class InheritanceError:
-    """A located error produced by the inheritance visitor.
-
-    Each error carries a ``message_kwargs`` dict whose keys match
-    the format placeholders in the associated :class:`ErrorCode`.
-    For example, INH001 uses ``{"base": "ClassName"}`` while INH002
-    uses ``{"cls": "MyABC", "method": "concrete_helper"}``.
-    """
+    """INH001 error: inheritance from an internal class."""
 
     line: int
     col: int
     code: ErrorCode
-    message_kwargs: dict[str, str]
+    base: str
 
     def format(self) -> str:
         """Return the full flake8 error string."""
-        return self.code.format(**self.message_kwargs)
+        return self.code.format(base=self.base)
 
     def as_flake8_tuple(self) -> tuple[int, int, str, type]:
         """Return the ``(line, col, message, type)`` tuple flake8 expects."""
         return (self.line, self.col, self.format(), type(self))
+
+
+@dataclass(frozen=True)
+class ABCPurityError:
+    """INH002 error: concrete method in an abstract base class."""
+
+    line: int
+    col: int
+    code: ErrorCode
+    cls: str
+    method: str
+
+    def format(self) -> str:
+        """Return the full flake8 error string."""
+        return self.code.format(cls=self.cls, method=self.method)
+
+    def as_flake8_tuple(self) -> tuple[int, int, str, type]:
+        """Return the ``(line, col, message, type)`` tuple flake8 expects."""
+        return (self.line, self.col, self.format(), type(self))
+
+
+LintError = InheritanceError | ABCPurityError
 
 
 class ImportTracker(ast.NodeVisitor):
@@ -151,7 +167,7 @@ class InheritanceVisitor(ast.NodeVisitor):
                         line=node.lineno,
                         col=node.col_offset,
                         code=INH001,
-                        message_kwargs={"base": base_name},
+                        base=base_name,
                     )
                 )
                 continue
@@ -163,7 +179,7 @@ class InheritanceVisitor(ast.NodeVisitor):
                         line=node.lineno,
                         col=node.col_offset,
                         code=INH001,
-                        message_kwargs={"base": base_name},
+                        base=base_name,
                     )
                 )
 
@@ -181,7 +197,7 @@ class ABCPurityVisitor(ast.NodeVisitor):
     def __init__(self, import_tracker: ImportTracker) -> None:
         """Initialize with a pre-populated import tracker."""
         self._tracker = import_tracker
-        self.errors: list[InheritanceError] = []
+        self.errors: list[ABCPurityError] = []
         self._abc_local_names = self._resolve_names_for("ABC")
         self._abcmeta_local_names = self._resolve_names_for("ABCMeta")
         self._abstractmethod_local_names = self._resolve_names_for("abstractmethod")
@@ -288,11 +304,12 @@ class ABCPurityVisitor(ast.NodeVisitor):
 
                 # Concrete method found - flag it
                 self.errors.append(
-                    InheritanceError(
+                    ABCPurityError(
                         line=item.lineno,
                         col=item.col_offset,
                         code=INH002,
-                        message_kwargs={"cls": node.name, "method": item.name},
+                        cls=node.name,
+                        method=item.name,
                     ),
                 )
 

--- a/src/flake8_inheritance/visitors.py
+++ b/src/flake8_inheritance/visitors.py
@@ -20,10 +20,15 @@ class InheritanceError:
     col: int
     code: ErrorCode
     base_name: str
+    class_name: str = ""
 
     def format(self) -> str:
         """Return the full flake8 error string."""
-        return self.code.format(base=self.base_name)
+        return self.code.format(
+            base=self.base_name,
+            cls=self.class_name,
+            method=self.base_name,
+        )
 
     def as_flake8_tuple(self) -> tuple[int, int, str, type]:
         """Return the ``(line, col, message, type)`` tuple flake8 expects."""
@@ -36,6 +41,7 @@ class ImportTracker(ast.NodeVisitor):
     def __init__(self, project_package: str | None = None) -> None:
         """Initialize tracker with an optional project package name."""
         self.imports: dict[str, str] = {}
+        self.original_names: dict[str, str] = {}
         self._project_package = project_package
 
     def visit_Import(self, node: ast.Import) -> None:  # noqa: N802
@@ -44,6 +50,7 @@ class ImportTracker(ast.NodeVisitor):
             top_level = alias.name.split(".")[0]
             local_name = alias.asname or top_level
             self.imports[local_name] = top_level
+            self.original_names[local_name] = alias.name
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:  # noqa: N802
         """Record modules imported with ``from ... import ...`` statements."""
@@ -57,6 +64,7 @@ class ImportTracker(ast.NodeVisitor):
         for alias in node.names:
             local_name = alias.asname or alias.name
             self.imports[local_name] = source_module
+            self.original_names[local_name] = alias.name
 
     def classify(self, local_name: str) -> str:
         """Return classification for a local import name."""
@@ -184,44 +192,93 @@ class ABCPurityVisitor(ast.NodeVisitor):
         """Initialize with a pre-populated import tracker."""
         self._tracker = import_tracker
         self.errors: list[InheritanceError] = []
-        self._abc_local_names: set[str] = self._resolve_abc_names()
-        self._abcmeta_local_names: set[str] = self._resolve_abcmeta_names()
+        self._abc_local_names = self._resolve_names_for("ABC")
+        self._abcmeta_local_names = self._resolve_names_for("ABCMeta")
+        self._abstractmethod_local_names = self._resolve_names_for("abstractmethod")
+        self._abc_module_aliases = self._resolve_abc_module_aliases()
 
-    def _resolve_abc_names(self) -> set[str]:
-        """Find all local names that map to ``abc.ABC``."""
+    def _resolve_names_for(self, original: str) -> set[str]:
+        """Find all local names that were imported as *original* from ``abc``."""
         names: set[str] = set()
         for local_name, source in self._tracker.imports.items():
-            if source == "abc" and local_name not in ("abstractmethod",):
-                # Could be ABC or ABCMeta; we only want ABC here
-                # We check by looking at the original import name
+            if source == "abc" and self._tracker.original_names.get(local_name) == original:
                 names.add(local_name)
-        # Filter: we need to distinguish ABC from ABCMeta
-        # Re-check by looking at what was actually imported
         return names
 
-    def _resolve_abcmeta_names(self) -> set[str]:
-        """Find all local names that map to ``abc.ABCMeta``."""
-        # This is resolved during _is_abc check by looking at metaclass keywords
-        return set()
+    def _resolve_abc_module_aliases(self) -> set[str]:
+        """Find local names that are module-level imports of ``abc``.
+
+        Handles ``import abc`` and ``import abc as a``.
+        """
+        names: set[str] = set()
+        for local_name, source in self._tracker.imports.items():
+            if source == "abc" and self._tracker.original_names.get(local_name) == "abc":
+                names.add(local_name)
+        return names
+
+    def _is_abc_base(self, base_name: str) -> bool:
+        """Check if a resolved base name refers to ``abc.ABC``.
+
+        Handles both direct (``ABC``) and module-qualified (``abc.ABC``)
+        forms, including aliases.
+        """
+        # Direct: from abc import ABC [as X]
+        if base_name in self._abc_local_names:
+            return True
+        # Module-qualified: import abc [as a]; class X(a.ABC)
+        parts = base_name.split(".")
+        return (
+            len(parts) == 2  # noqa: PLR2004
+            and parts[0] in self._abc_module_aliases
+            and parts[1] == "ABC"
+        )
+
+    def _is_abcmeta_keyword(self, keyword: ast.keyword) -> bool:
+        """Check if a class keyword is ``metaclass=ABCMeta`` (any form)."""
+        if keyword.arg != "metaclass":
+            return False
+        # Direct: from abc import ABCMeta [as X]; metaclass=X
+        if isinstance(keyword.value, ast.Name):
+            return keyword.value.id in self._abcmeta_local_names
+        # Module-qualified: import abc [as a]; metaclass=a.ABCMeta
+        if isinstance(keyword.value, ast.Attribute):
+            resolved = _resolve_base(keyword.value)
+            if resolved is not None:
+                parts = resolved.split(".")
+                if (
+                    len(parts) == 2  # noqa: PLR2004
+                    and parts[0] in self._abc_module_aliases
+                    and parts[1] == "ABCMeta"
+                ):
+                    return True
+        return False
 
     def _is_abc(self, node: ast.ClassDef) -> bool:
         """Check if a class is an ABC (inherits from ABC or uses ABCMeta)."""
-        # Check base classes for ABC
         for base in node.bases:
             base_name = _resolve_base(base)
-            if base_name is not None and base_name in self._abc_local_names:
-                # Verify it comes from the abc module
-                root = base_name.split(".")[0]
-                if self._tracker.imports.get(root) == "abc":
-                    return True
+            if base_name is not None and self._is_abc_base(base_name):
+                return True
+        return any(self._is_abcmeta_keyword(kw) for kw in node.keywords)
 
-        # Check keywords for metaclass=ABCMeta
-        for keyword in node.keywords:
-            if keyword.arg == "metaclass" and isinstance(keyword.value, ast.Name):
-                kw_name = keyword.value.id
-                if self._tracker.imports.get(kw_name) == "abc":
+    def _is_abstractmethod(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+        """Check if a method is decorated with ``@abstractmethod`` (any form)."""
+        for decorator in node.decorator_list:
+            # Direct: @abstractmethod or @am (alias)
+            if isinstance(decorator, ast.Name):
+                if decorator.id in self._abstractmethod_local_names:
                     return True
-
+            # Module-qualified: @abc.abstractmethod or @a.abstractmethod
+            elif isinstance(decorator, ast.Attribute):
+                resolved = _resolve_base(decorator)
+                if resolved is not None:
+                    parts = resolved.split(".")
+                    if (
+                        len(parts) == 2  # noqa: PLR2004
+                        and parts[0] in self._abc_module_aliases
+                        and parts[1] == "abstractmethod"
+                    ):
+                        return True
         return False
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
@@ -236,8 +293,7 @@ class ABCPurityVisitor(ast.NodeVisitor):
                     continue
 
                 # Check if decorated with @abstractmethod
-                decorator_names = _get_decorator_names(item)
-                if "abstractmethod" in decorator_names:
+                if self._is_abstractmethod(item):
                     continue
 
                 # Concrete method found - flag it
@@ -247,6 +303,7 @@ class ABCPurityVisitor(ast.NodeVisitor):
                         col=item.col_offset,
                         code=INH002,
                         base_name=item.name,
+                        class_name=node.name,
                     ),
                 )
 

--- a/src/flake8_inheritance/visitors.py
+++ b/src/flake8_inheritance/visitors.py
@@ -14,21 +14,22 @@ RELATIVE_SENTINEL: Final[str] = "__relative__"
 
 @dataclass(frozen=True)
 class InheritanceError:
-    """A located error produced by the inheritance visitor."""
+    """A located error produced by the inheritance visitor.
+
+    Each error carries a ``message_kwargs`` dict whose keys match
+    the format placeholders in the associated :class:`ErrorCode`.
+    For example, INH001 uses ``{"base": "ClassName"}`` while INH002
+    uses ``{"cls": "MyABC", "method": "concrete_helper"}``.
+    """
 
     line: int
     col: int
     code: ErrorCode
-    base_name: str
-    class_name: str = ""
+    message_kwargs: dict[str, str]
 
     def format(self) -> str:
         """Return the full flake8 error string."""
-        return self.code.format(
-            base=self.base_name,
-            cls=self.class_name,
-            method=self.base_name,
-        )
+        return self.code.format(**self.message_kwargs)
 
     def as_flake8_tuple(self) -> tuple[int, int, str, type]:
         """Return the ``(line, col, message, type)`` tuple flake8 expects."""
@@ -150,7 +151,7 @@ class InheritanceVisitor(ast.NodeVisitor):
                         line=node.lineno,
                         col=node.col_offset,
                         code=INH001,
-                        base_name=base_name,
+                        message_kwargs={"base": base_name},
                     )
                 )
                 continue
@@ -162,22 +163,11 @@ class InheritanceVisitor(ast.NodeVisitor):
                         line=node.lineno,
                         col=node.col_offset,
                         code=INH001,
-                        base_name=base_name,
+                        message_kwargs={"base": base_name},
                     )
                 )
 
         self.generic_visit(node)
-
-
-def _get_decorator_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
-    """Return the set of simple decorator names on a function node."""
-    names: set[str] = set()
-    for decorator in node.decorator_list:
-        if isinstance(decorator, ast.Name):
-            names.add(decorator.id)
-        elif isinstance(decorator, ast.Attribute):
-            names.add(decorator.attr)
-    return names
 
 
 class ABCPurityVisitor(ast.NodeVisitor):
@@ -302,8 +292,7 @@ class ABCPurityVisitor(ast.NodeVisitor):
                         line=item.lineno,
                         col=item.col_offset,
                         code=INH002,
-                        base_name=item.name,
-                        class_name=node.name,
+                        message_kwargs={"cls": node.name, "method": item.name},
                     ),
                 )
 

--- a/src/flake8_inheritance/visitors.py
+++ b/src/flake8_inheritance/visitors.py
@@ -7,7 +7,7 @@ import sys
 from dataclasses import dataclass
 from typing import Final
 
-from flake8_inheritance.codes import INH001, ErrorCode
+from flake8_inheritance.codes import INH001, INH002, ErrorCode
 
 RELATIVE_SENTINEL: Final[str] = "__relative__"
 
@@ -156,6 +156,98 @@ class InheritanceVisitor(ast.NodeVisitor):
                         code=INH001,
                         base_name=base_name,
                     )
+                )
+
+        self.generic_visit(node)
+
+
+def _get_decorator_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    """Return the set of simple decorator names on a function node."""
+    names: set[str] = set()
+    for decorator in node.decorator_list:
+        if isinstance(decorator, ast.Name):
+            names.add(decorator.id)
+        elif isinstance(decorator, ast.Attribute):
+            names.add(decorator.attr)
+    return names
+
+
+class ABCPurityVisitor(ast.NodeVisitor):
+    """Detect impure ABCs (INH002).
+
+    Walks ``ast.ClassDef`` nodes and flags concrete (non-abstract) methods
+    in classes that inherit from ``abc.ABC`` or use ``abc.ABCMeta`` as their
+    metaclass.  Dunder methods (e.g. ``__init__``) are always allowed.
+    """
+
+    def __init__(self, import_tracker: ImportTracker) -> None:
+        """Initialize with a pre-populated import tracker."""
+        self._tracker = import_tracker
+        self.errors: list[InheritanceError] = []
+        self._abc_local_names: set[str] = self._resolve_abc_names()
+        self._abcmeta_local_names: set[str] = self._resolve_abcmeta_names()
+
+    def _resolve_abc_names(self) -> set[str]:
+        """Find all local names that map to ``abc.ABC``."""
+        names: set[str] = set()
+        for local_name, source in self._tracker.imports.items():
+            if source == "abc" and local_name not in ("abstractmethod",):
+                # Could be ABC or ABCMeta; we only want ABC here
+                # We check by looking at the original import name
+                names.add(local_name)
+        # Filter: we need to distinguish ABC from ABCMeta
+        # Re-check by looking at what was actually imported
+        return names
+
+    def _resolve_abcmeta_names(self) -> set[str]:
+        """Find all local names that map to ``abc.ABCMeta``."""
+        # This is resolved during _is_abc check by looking at metaclass keywords
+        return set()
+
+    def _is_abc(self, node: ast.ClassDef) -> bool:
+        """Check if a class is an ABC (inherits from ABC or uses ABCMeta)."""
+        # Check base classes for ABC
+        for base in node.bases:
+            base_name = _resolve_base(base)
+            if base_name is not None and base_name in self._abc_local_names:
+                # Verify it comes from the abc module
+                root = base_name.split(".")[0]
+                if self._tracker.imports.get(root) == "abc":
+                    return True
+
+        # Check keywords for metaclass=ABCMeta
+        for keyword in node.keywords:
+            if keyword.arg == "metaclass" and isinstance(keyword.value, ast.Name):
+                kw_name = keyword.value.id
+                if self._tracker.imports.get(kw_name) == "abc":
+                    return True
+
+        return False
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+        """Process a class definition, checking ABC purity."""
+        if self._is_abc(node):
+            for item in node.body:
+                if not isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef):
+                    continue
+
+                # Allow dunder methods
+                if item.name.startswith("__") and item.name.endswith("__"):
+                    continue
+
+                # Check if decorated with @abstractmethod
+                decorator_names = _get_decorator_names(item)
+                if "abstractmethod" in decorator_names:
+                    continue
+
+                # Concrete method found - flag it
+                self.errors.append(
+                    InheritanceError(
+                        line=item.lineno,
+                        col=item.col_offset,
+                        code=INH002,
+                        base_name=item.name,
+                    ),
                 )
 
         self.generic_visit(node)

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -647,3 +647,139 @@ class MyDict(OrderedDict):
         return 42
 """
         assert collect_inh002_errors(source) == []
+
+
+class TestINH002ModuleQualifiedABC:
+    """Module-qualified ABC usage: ``import abc; class X(abc.ABC): ...``."""
+
+    def test_import_abc_dot_abc_detected(self) -> None:
+        source = """\
+import abc
+
+class MyABC(abc.ABC):
+    @abc.abstractmethod
+    def do_thing(self):
+        pass
+
+    def concrete_helper(self):
+        return 42
+"""
+        errors = collect_inh002_errors(source)
+        assert flagged_methods(errors) == ["concrete_helper"]
+
+    def test_import_abc_dot_abc_pure_passes(self) -> None:
+        source = """\
+import abc
+
+class MyABC(abc.ABC):
+    @abc.abstractmethod
+    def do_thing(self):
+        pass
+"""
+        assert collect_inh002_errors(source) == []
+
+    def test_import_abc_dot_abcmeta_metaclass(self) -> None:
+        source = """\
+import abc
+
+class MyABC(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def do_thing(self):
+        pass
+
+    def concrete_helper(self):
+        return 42
+"""
+        errors = collect_inh002_errors(source)
+        assert flagged_methods(errors) == ["concrete_helper"]
+
+    def test_import_abc_aliased_module(self) -> None:
+        """``import abc as a; class X(a.ABC): ...``."""
+        source = """\
+import abc as a
+
+class MyABC(a.ABC):
+    @a.abstractmethod
+    def do_thing(self):
+        pass
+
+    def concrete_helper(self):
+        return 42
+"""
+        errors = collect_inh002_errors(source)
+        assert flagged_methods(errors) == ["concrete_helper"]
+
+
+class TestINH002ABCMetaFalsePositives:
+    """ABCMeta in base classes should not be treated as ABC base."""
+
+    def test_class_inheriting_from_abcmeta_not_treated_as_abc_base(self) -> None:
+        """``class X(ABCMeta)`` is a metaclass def, not an ABC."""
+        source = """\
+from abc import ABCMeta
+
+class MyMeta(ABCMeta):
+    def some_method(self):
+        return 42
+"""
+        assert collect_inh002_errors(source) == []
+
+    def test_metaclass_abstractmethod_not_abc(self) -> None:
+        """``metaclass=abstractmethod`` should not be treated as ABC."""
+        source = """\
+from abc import abstractmethod
+
+class MyClass(metaclass=abstractmethod):
+    def some_method(self):
+        return 42
+"""
+        assert collect_inh002_errors(source) == []
+
+
+class TestINH002AbstractmethodAliases:
+    """Aliased abstractmethod imports should be resolved."""
+
+    def test_abstractmethod_alias_recognized(self) -> None:
+        source = """\
+from abc import ABC, abstractmethod as am
+
+class MyABC(ABC):
+    @am
+    def do_thing(self):
+        pass
+"""
+        assert collect_inh002_errors(source) == []
+
+    def test_module_qualified_abstractmethod_recognized(self) -> None:
+        source = """\
+import abc
+
+class MyABC(abc.ABC):
+    @abc.abstractmethod
+    def do_thing(self):
+        pass
+"""
+        assert collect_inh002_errors(source) == []
+
+
+class TestINH002ErrorFormat:
+    """INH002 errors should format correctly with class and method names."""
+
+    def test_error_format_includes_class_and_method(self) -> None:
+        source = """\
+from abc import ABC, abstractmethod
+
+class MyABC(ABC):
+    @abstractmethod
+    def do_thing(self):
+        pass
+
+    def concrete_helper(self):
+        return 42
+"""
+        errors = collect_inh002_errors(source)
+        assert len(errors) == 1
+        formatted = errors[0].format()
+        assert "MyABC" in formatted
+        assert "concrete_helper" in formatted
+        assert formatted.startswith("INH002")

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -6,9 +6,10 @@ import ast
 
 import pytest
 
-from flake8_inheritance.codes import INH001
+from flake8_inheritance.codes import INH001, INH002
 from flake8_inheritance.visitors import (
     RELATIVE_SENTINEL,
+    ABCPurityVisitor,
     ImportTracker,
     InheritanceError,
     InheritanceVisitor,
@@ -355,3 +356,294 @@ class Child(SomeUnknownBase):
     pass
 """
         assert collect_errors(source) == []
+
+
+# ---------------------------------------------------------------------------
+# Helpers for INH002 tests
+# ---------------------------------------------------------------------------
+
+
+def collect_inh002_errors(source: str) -> list[InheritanceError]:
+    """Parse source, run ImportTracker + ABCPurityVisitor, return errors."""
+    tree = ast.parse(source)
+    tracker = ImportTracker()
+    tracker.visit(tree)
+    visitor = ABCPurityVisitor(import_tracker=tracker)
+    visitor.visit(tree)
+    return visitor.errors
+
+
+def flagged_methods(errors: list[InheritanceError]) -> list[str]:
+    """Return just the base names (method names) from INH002 errors."""
+    return [e.base_name for e in errors]
+
+
+# ---------------------------------------------------------------------------
+# INH002 — detect impure ABCs (concrete methods in abstract base classes)
+# ---------------------------------------------------------------------------
+
+
+class TestINH002PureABC:
+    """Pure ABCs (only abstract methods) should not be flagged."""
+
+    def test_pure_abc_passes(self) -> None:
+        source = """\
+from abc import ABC, abstractmethod
+
+class MyABC(ABC):
+    @abstractmethod
+    def do_thing(self):
+        pass
+
+    @abstractmethod
+    def do_other(self):
+        pass
+"""
+        assert collect_inh002_errors(source) == []
+
+    def test_empty_abc_passes(self) -> None:
+        source = """\
+from abc import ABC
+
+class MyABC(ABC):
+    pass
+"""
+        assert collect_inh002_errors(source) == []
+
+
+class TestINH002ConcreteMethodFlagged:
+    """Concrete methods in ABCs should be flagged."""
+
+    def test_concrete_method_in_abc_flagged(self) -> None:
+        source = """\
+from abc import ABC, abstractmethod
+
+class MyABC(ABC):
+    @abstractmethod
+    def do_thing(self):
+        pass
+
+    def concrete_helper(self):
+        return 42
+"""
+        errors = collect_inh002_errors(source)
+        assert len(errors) == 1
+        assert errors[0].code is INH002
+        assert errors[0].base_name == "concrete_helper"
+
+    def test_multiple_concrete_methods_flagged(self) -> None:
+        source = """\
+from abc import ABC, abstractmethod
+
+class MyABC(ABC):
+    @abstractmethod
+    def do_thing(self):
+        pass
+
+    def helper_one(self):
+        return 1
+
+    def helper_two(self):
+        return 2
+"""
+        errors = collect_inh002_errors(source)
+        assert flagged_methods(errors) == ["helper_one", "helper_two"]
+
+    def test_all_concrete_no_abstract_flagged(self) -> None:
+        """An ABC with no abstract methods at all flags every method."""
+        source = """\
+from abc import ABC
+
+class MyABC(ABC):
+    def foo(self):
+        return 1
+
+    def bar(self):
+        return 2
+"""
+        errors = collect_inh002_errors(source)
+        assert flagged_methods(errors) == ["foo", "bar"]
+
+
+class TestINH002InitAllowed:
+    """__init__ should be allowed by default in ABCs."""
+
+    def test_init_allowed(self) -> None:
+        source = """\
+from abc import ABC, abstractmethod
+
+class MyABC(ABC):
+    def __init__(self, name):
+        self.name = name
+
+    @abstractmethod
+    def do_thing(self):
+        pass
+"""
+        assert collect_inh002_errors(source) == []
+
+    def test_dunder_methods_allowed(self) -> None:
+        """Dunder methods like __init__, __repr__ etc. should be allowed."""
+        source = """\
+from abc import ABC, abstractmethod
+
+class MyABC(ABC):
+    def __init__(self):
+        pass
+
+    def __repr__(self):
+        return "MyABC()"
+
+    @abstractmethod
+    def do_thing(self):
+        pass
+"""
+        assert collect_inh002_errors(source) == []
+
+
+class TestINH002DecoratorCombinations:
+    """@staticmethod + @abstractmethod and @classmethod + @abstractmethod pass."""
+
+    def test_staticmethod_abstractmethod_passes(self) -> None:
+        source = """\
+from abc import ABC, abstractmethod
+
+class MyABC(ABC):
+    @staticmethod
+    @abstractmethod
+    def do_thing():
+        pass
+"""
+        assert collect_inh002_errors(source) == []
+
+    def test_classmethod_abstractmethod_passes(self) -> None:
+        source = """\
+from abc import ABC, abstractmethod
+
+class MyABC(ABC):
+    @classmethod
+    @abstractmethod
+    def do_thing(cls):
+        pass
+"""
+        assert collect_inh002_errors(source) == []
+
+    def test_plain_staticmethod_flagged(self) -> None:
+        """A staticmethod without @abstractmethod is concrete."""
+        source = """\
+from abc import ABC, abstractmethod
+
+class MyABC(ABC):
+    @abstractmethod
+    def do_thing(self):
+        pass
+
+    @staticmethod
+    def helper():
+        return 42
+"""
+        errors = collect_inh002_errors(source)
+        assert flagged_methods(errors) == ["helper"]
+
+    def test_plain_classmethod_flagged(self) -> None:
+        """A classmethod without @abstractmethod is concrete."""
+        source = """\
+from abc import ABC, abstractmethod
+
+class MyABC(ABC):
+    @abstractmethod
+    def do_thing(self):
+        pass
+
+    @classmethod
+    def create(cls):
+        return cls()
+"""
+        errors = collect_inh002_errors(source)
+        assert flagged_methods(errors) == ["create"]
+
+
+class TestINH002ABCMetaDetection:
+    """ABCMeta metaclass should be detected as ABC."""
+
+    def test_abcmeta_metaclass_detected(self) -> None:
+        source = """\
+from abc import ABCMeta, abstractmethod
+
+class MyABC(metaclass=ABCMeta):
+    @abstractmethod
+    def do_thing(self):
+        pass
+
+    def concrete_helper(self):
+        return 42
+"""
+        errors = collect_inh002_errors(source)
+        assert flagged_methods(errors) == ["concrete_helper"]
+
+    def test_pure_abcmeta_passes(self) -> None:
+        source = """\
+from abc import ABCMeta, abstractmethod
+
+class MyABC(metaclass=ABCMeta):
+    @abstractmethod
+    def do_thing(self):
+        pass
+"""
+        assert collect_inh002_errors(source) == []
+
+
+class TestINH002ABCAlias:
+    """ABC imported with an alias should still be detected."""
+
+    def test_abc_alias_detected(self) -> None:
+        source = """\
+from abc import ABC as AbstractBase, abstractmethod
+
+class MyABC(AbstractBase):
+    @abstractmethod
+    def do_thing(self):
+        pass
+
+    def concrete_helper(self):
+        return 42
+"""
+        errors = collect_inh002_errors(source)
+        assert flagged_methods(errors) == ["concrete_helper"]
+
+    def test_abcmeta_alias_detected(self) -> None:
+        source = """\
+from abc import ABCMeta as Meta, abstractmethod
+
+class MyABC(metaclass=Meta):
+    @abstractmethod
+    def do_thing(self):
+        pass
+
+    def concrete_helper(self):
+        return 42
+"""
+        errors = collect_inh002_errors(source)
+        assert flagged_methods(errors) == ["concrete_helper"]
+
+
+class TestINH002NonABCIgnored:
+    """Non-ABC classes should not be checked for method purity."""
+
+    def test_regular_class_ignored(self) -> None:
+        source = """\
+class RegularClass:
+    def method(self):
+        return 42
+"""
+        assert collect_inh002_errors(source) == []
+
+    def test_class_inheriting_from_non_abc(self) -> None:
+        source = """\
+from collections import OrderedDict
+
+class MyDict(OrderedDict):
+    def custom_method(self):
+        return 42
+"""
+        assert collect_inh002_errors(source) == []

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -9,6 +9,7 @@ import pytest
 from flake8_inheritance.codes import INH001, INH002
 from flake8_inheritance.visitors import (
     RELATIVE_SENTINEL,
+    ABCPurityError,
     ABCPurityVisitor,
     ImportTracker,
     InheritanceError,
@@ -98,7 +99,7 @@ def collect_errors(
 
 def flagged_bases(errors: list[InheritanceError]) -> list[str]:
     """Return just the base names from a list of INH001 errors."""
-    return [e.message_kwargs["base"] for e in errors]
+    return [e.base for e in errors]
 
 
 # ---------------------------------------------------------------------------
@@ -363,7 +364,7 @@ class Child(SomeUnknownBase):
 # ---------------------------------------------------------------------------
 
 
-def collect_inh002_errors(source: str) -> list[InheritanceError]:
+def collect_inh002_errors(source: str) -> list[ABCPurityError]:
     """Parse source, run ImportTracker + ABCPurityVisitor, return errors."""
     tree = ast.parse(source)
     tracker = ImportTracker()
@@ -373,9 +374,9 @@ def collect_inh002_errors(source: str) -> list[InheritanceError]:
     return visitor.errors
 
 
-def flagged_methods(errors: list[InheritanceError]) -> list[str]:
+def flagged_methods(errors: list[ABCPurityError]) -> list[str]:
     """Return just the method names from INH002 errors."""
-    return [e.message_kwargs["method"] for e in errors]
+    return [e.method for e in errors]
 
 
 # ---------------------------------------------------------------------------
@@ -429,8 +430,8 @@ class MyABC(ABC):
         errors = collect_inh002_errors(source)
         assert len(errors) == 1
         assert errors[0].code is INH002
-        assert errors[0].message_kwargs["method"] == "concrete_helper"
-        assert errors[0].message_kwargs["cls"] == "MyABC"
+        assert errors[0].method == "concrete_helper"
+        assert errors[0].cls == "MyABC"
 
     def test_multiple_concrete_methods_flagged(self) -> None:
         source = """\
@@ -784,3 +785,50 @@ class MyABC(ABC):
         assert "MyABC" in formatted
         assert "concrete_helper" in formatted
         assert formatted.startswith("INH002")
+
+
+# ---------------------------------------------------------------------------
+# Error object immutability and hashability
+# ---------------------------------------------------------------------------
+
+
+class TestErrorImmutability:
+    """Error objects must be truly immutable and hashable."""
+
+    def test_inh001_error_is_hashable(self) -> None:
+        errors = collect_errors("class A:\n    pass\n\nclass B(A):\n    pass\n")
+        assert len(errors) == 1
+        # Must be hashable (usable in sets and as dict keys)
+        hash(errors[0])
+        assert len({errors[0], errors[0]}) == 1
+
+    def test_inh002_error_is_hashable(self) -> None:
+        source = """\
+from abc import ABC
+
+class MyABC(ABC):
+    def foo(self):
+        return 1
+"""
+        errors = collect_inh002_errors(source)
+        assert len(errors) == 1
+        # Must be hashable (usable in sets and as dict keys)
+        hash(errors[0])
+        assert len({errors[0], errors[0]}) == 1
+
+    def test_inh001_error_is_immutable(self) -> None:
+        errors = collect_errors("class A:\n    pass\n\nclass B(A):\n    pass\n")
+        with pytest.raises(AttributeError):
+            errors[0].line = 99  # type: ignore[misc]
+
+    def test_inh002_error_is_immutable(self) -> None:
+        source = """\
+from abc import ABC
+
+class MyABC(ABC):
+    def foo(self):
+        return 1
+"""
+        errors = collect_inh002_errors(source)
+        with pytest.raises(AttributeError):
+            errors[0].line = 99  # type: ignore[misc]

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -97,8 +97,8 @@ def collect_errors(
 
 
 def flagged_bases(errors: list[InheritanceError]) -> list[str]:
-    """Return just the base names from a list of errors."""
-    return [e.base_name for e in errors]
+    """Return just the base names from a list of INH001 errors."""
+    return [e.message_kwargs["base"] for e in errors]
 
 
 # ---------------------------------------------------------------------------
@@ -374,8 +374,8 @@ def collect_inh002_errors(source: str) -> list[InheritanceError]:
 
 
 def flagged_methods(errors: list[InheritanceError]) -> list[str]:
-    """Return just the base names (method names) from INH002 errors."""
-    return [e.base_name for e in errors]
+    """Return just the method names from INH002 errors."""
+    return [e.message_kwargs["method"] for e in errors]
 
 
 # ---------------------------------------------------------------------------
@@ -429,7 +429,8 @@ class MyABC(ABC):
         errors = collect_inh002_errors(source)
         assert len(errors) == 1
         assert errors[0].code is INH002
-        assert errors[0].base_name == "concrete_helper"
+        assert errors[0].message_kwargs["method"] == "concrete_helper"
+        assert errors[0].message_kwargs["cls"] == "MyABC"
 
     def test_multiple_concrete_methods_flagged(self) -> None:
         source = """\


### PR DESCRIPTION
Add ABCPurityVisitor that flags concrete methods in abstract base
classes. ABCs are detected via abc.ABC inheritance or ABCMeta metaclass,
including aliased imports. Dunder methods are always allowed. Methods
decorated with @abstractmethod (alone or combined with @staticmethod/
@classmethod) are treated as abstract.

https://claude.ai/code/session_01La3JtUubnNgytxfSFVnm3U