### PR TITLE
Wire InheritanceChecker.run() to visitor engine (TDD)

### DIFF
--- a/src/flake8_inheritance/checker.py
+++ b/src/flake8_inheritance/checker.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 import importlib.metadata
 from typing import TYPE_CHECKING, ClassVar
 
+from flake8_inheritance.visitors import (
+    ABCPurityVisitor,
+    ImportTracker,
+    InheritanceVisitor,
+    _collect_module_class_names,
+)
+
 if TYPE_CHECKING:
     import ast
     from collections.abc import Generator
@@ -27,5 +34,19 @@ class InheritanceChecker:
         self._tree = tree
 
     def run(self) -> Generator[tuple[int, int, str, type], None, None]:
-        """Run the checker. Yields nothing until rules are implemented."""
-        yield from ()
+        """Run the checker and yield flake8 error tuples."""
+        tracker = ImportTracker()
+        tracker.visit(self._tree)
+
+        module_classes = frozenset(_collect_module_class_names(self._tree))
+
+        inh_visitor = InheritanceVisitor(tracker, module_classes)
+        inh_visitor.visit(self._tree)
+
+        abc_visitor = ABCPurityVisitor(tracker)
+        abc_visitor.visit(self._tree)
+
+        for inh_error in inh_visitor.errors:
+            yield inh_error.as_flake8_tuple()
+        for abc_error in abc_visitor.errors:
+            yield abc_error.as_flake8_tuple()

--- a/src/flake8_inheritance/checker.py
+++ b/src/flake8_inheritance/checker.py
@@ -46,7 +46,8 @@ class InheritanceChecker:
         abc_visitor = ABCPurityVisitor(tracker)
         abc_visitor.visit(self._tree)
 
+        checker_cls = type(self)
         for inh_error in inh_visitor.errors:
-            yield inh_error.as_flake8_tuple()
+            yield (inh_error.line, inh_error.col, inh_error.format(), checker_cls)
         for abc_error in abc_visitor.errors:
-            yield abc_error.as_flake8_tuple()
+            yield (abc_error.line, abc_error.col, abc_error.format(), checker_cls)

--- a/src/flake8_inheritance/checker.py
+++ b/src/flake8_inheritance/checker.py
@@ -9,7 +9,7 @@ from flake8_inheritance.visitors import (
     ABCPurityVisitor,
     ImportTracker,
     InheritanceVisitor,
-    _collect_module_class_names,
+    collect_module_class_names,
 )
 
 if TYPE_CHECKING:
@@ -38,7 +38,7 @@ class InheritanceChecker:
         tracker = ImportTracker()
         tracker.visit(self._tree)
 
-        module_classes = frozenset(_collect_module_class_names(self._tree))
+        module_classes = frozenset(collect_module_class_names(self._tree))
 
         inh_visitor = InheritanceVisitor(tracker, module_classes)
         inh_visitor.visit(self._tree)

--- a/src/flake8_inheritance/visitors.py
+++ b/src/flake8_inheritance/visitors.py
@@ -122,7 +122,7 @@ def _resolve_base(node: ast.expr) -> str | None:
     return None
 
 
-def _collect_module_class_names(tree: ast.AST) -> set[str]:
+def collect_module_class_names(tree: ast.AST) -> set[str]:
     """Pre-scan the module body and return all top-level class names."""
     names: set[str] = set()
     if isinstance(tree, ast.Module):

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -55,6 +55,22 @@ class TestCheckerINH001:
         assert "INH001" in message
         assert "BaseModel" in message
 
+    def test_absolute_project_import_not_flagged_without_config(self) -> None:
+        """Absolute project imports are not flagged without project_package config.
+
+        The checker does not yet support ``--project-packages``; that option
+        will be wired in Task 3.2 (add_options / parse_options).  Until then,
+        absolute imports from the user's own project are classified as
+        ``external`` and silently allowed.
+        """
+        source = """\
+            from myproject.models import Base
+
+            class Child(Base):
+                pass
+        """
+        assert _run_checker(source) == []
+
     def test_no_inheritance_no_errors(self) -> None:
         """A file with no inheritance produces no errors."""
         source = """\

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -6,7 +6,6 @@ import ast
 import textwrap
 
 from flake8_inheritance.checker import InheritanceChecker
-from flake8_inheritance.visitors import ABCPurityError, InheritanceError
 
 
 def _run_checker(source: str) -> list[tuple[int, int, str, type]]:
@@ -36,7 +35,7 @@ class TestCheckerINH001:
         assert col == 0
         assert "INH001" in message
         assert "Base" in message
-        assert cls is InheritanceError
+        assert cls is InheritanceChecker
 
     def test_relative_import_inheritance(self) -> None:
         """Inheriting from a relative import triggers INH001."""
@@ -125,7 +124,7 @@ class TestCheckerINH002:
         assert "INH002" in message
         assert "MyABC" in message
         assert "concrete_method" in message
-        assert cls is ABCPurityError
+        assert cls is InheritanceChecker
 
     def test_pure_abc_no_errors(self) -> None:
         """An ABC with only abstract methods produces no errors."""
@@ -153,6 +152,42 @@ class TestCheckerINH002:
                     pass
         """
         assert _run_checker(source) == []
+
+
+class TestCheckerPluginType:
+    """The 4th element of each yielded tuple must be the checker class."""
+
+    def test_inh001_yields_checker_class(self) -> None:
+        """INH001 tuples carry InheritanceChecker as the plugin type."""
+        source = """\
+            class Base:
+                pass
+
+            class Child(Base):
+                pass
+        """
+        results = _run_checker(source)
+
+        assert len(results) == 1
+        assert results[0][3] is InheritanceChecker
+
+    def test_inh002_yields_checker_class(self) -> None:
+        """INH002 tuples carry InheritanceChecker as the plugin type."""
+        source = """\
+            from abc import ABC, abstractmethod
+
+            class MyABC(ABC):
+                @abstractmethod
+                def abstract_method(self):
+                    pass
+
+                def concrete_method(self):
+                    return 42
+        """
+        results = _run_checker(source)
+
+        assert len(results) == 1
+        assert results[0][3] is InheritanceChecker
 
 
 class TestCheckerCombined:

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -1,0 +1,208 @@
+"""Tests for InheritanceChecker.run() integration with visitors."""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+
+from flake8_inheritance.checker import InheritanceChecker
+from flake8_inheritance.visitors import ABCPurityError, InheritanceError
+
+
+def _run_checker(source: str) -> list[tuple[int, int, str, type]]:
+    """Parse *source* and return all errors from ``InheritanceChecker.run()``."""
+    tree = ast.parse(textwrap.dedent(source))
+    return list(InheritanceChecker(tree).run())
+
+
+class TestCheckerINH001:
+    """InheritanceChecker.run() yields INH001 errors for internal inheritance."""
+
+    def test_same_file_inheritance(self) -> None:
+        """Inheriting from a class defined in the same file triggers INH001."""
+        source = """\
+            class Base:
+                pass
+
+            class Child(Base):
+                pass
+        """
+        child_line = 4
+        results = _run_checker(source)
+
+        assert len(results) == 1
+        line, col, message, cls = results[0]
+        assert line == child_line
+        assert col == 0
+        assert "INH001" in message
+        assert "Base" in message
+        assert cls is InheritanceError
+
+    def test_relative_import_inheritance(self) -> None:
+        """Inheriting from a relative import triggers INH001."""
+        source = """\
+            from .models import BaseModel
+
+            class Child(BaseModel):
+                pass
+        """
+        child_line = 3
+        results = _run_checker(source)
+
+        assert len(results) == 1
+        line, col, message, cls = results[0]
+        assert line == child_line
+        assert col == 0
+        assert "INH001" in message
+        assert "BaseModel" in message
+
+    def test_no_inheritance_no_errors(self) -> None:
+        """A file with no inheritance produces no errors."""
+        source = """\
+            class Standalone:
+                pass
+        """
+        assert _run_checker(source) == []
+
+    def test_stdlib_inheritance_allowed(self) -> None:
+        """Inheriting from stdlib classes does not trigger INH001."""
+        source = """\
+            from collections import OrderedDict
+
+            class MyDict(OrderedDict):
+                pass
+        """
+        assert _run_checker(source) == []
+
+    def test_multiple_same_file_classes(self) -> None:
+        """Multiple internal inheritance violations each produce an error."""
+        source = """\
+            class A:
+                pass
+
+            class B:
+                pass
+
+            class C(A):
+                pass
+
+            class D(B):
+                pass
+        """
+        expected_count = 2
+        results = _run_checker(source)
+
+        assert len(results) == expected_count
+        messages = [r[2] for r in results]
+        assert any("A" in m for m in messages)
+        assert any("B" in m for m in messages)
+
+
+class TestCheckerINH002:
+    """InheritanceChecker.run() yields INH002 errors for impure ABCs."""
+
+    def test_concrete_method_in_abc(self) -> None:
+        """A concrete method in an ABC triggers INH002."""
+        source = """\
+            from abc import ABC, abstractmethod
+
+            class MyABC(ABC):
+                @abstractmethod
+                def abstract_method(self):
+                    pass
+
+                def concrete_method(self):
+                    return 42
+        """
+        concrete_line = 8
+        concrete_col = 4
+        results = _run_checker(source)
+
+        assert len(results) == 1
+        line, col, message, cls = results[0]
+        assert line == concrete_line
+        assert col == concrete_col
+        assert "INH002" in message
+        assert "MyABC" in message
+        assert "concrete_method" in message
+        assert cls is ABCPurityError
+
+    def test_pure_abc_no_errors(self) -> None:
+        """An ABC with only abstract methods produces no errors."""
+        source = """\
+            from abc import ABC, abstractmethod
+
+            class MyABC(ABC):
+                @abstractmethod
+                def do_something(self):
+                    pass
+        """
+        assert _run_checker(source) == []
+
+    def test_dunder_methods_allowed(self) -> None:
+        """Dunder methods in an ABC do not trigger INH002."""
+        source = """\
+            from abc import ABC, abstractmethod
+
+            class MyABC(ABC):
+                def __init__(self):
+                    self.x = 1
+
+                @abstractmethod
+                def do_something(self):
+                    pass
+        """
+        assert _run_checker(source) == []
+
+
+class TestCheckerCombined:
+    """InheritanceChecker.run() handles both INH001 and INH002 together."""
+
+    def test_both_errors_in_one_file(self) -> None:
+        """A file with both INH001 and INH002 violations yields both errors."""
+        source = """\
+            from abc import ABC, abstractmethod
+
+            class Base:
+                pass
+
+            class Child(Base):
+                pass
+
+            class MyABC(ABC):
+                @abstractmethod
+                def abstract_method(self):
+                    pass
+
+                def concrete_method(self):
+                    return 42
+        """
+        expected_count = 2
+        results = _run_checker(source)
+
+        assert len(results) == expected_count
+        codes = [r[2] for r in results]
+        assert any("INH001" in c for c in codes)
+        assert any("INH002" in c for c in codes)
+
+    def test_empty_module(self) -> None:
+        """An empty module produces no errors."""
+        assert _run_checker("") == []
+
+    def test_result_tuple_format(self) -> None:
+        """Each result is a 4-tuple of (int, int, str, type)."""
+        source = """\
+            class Base:
+                pass
+
+            class Child(Base):
+                pass
+        """
+        results = _run_checker(source)
+
+        assert len(results) == 1
+        line, col, message, cls = results[0]
+        assert isinstance(line, int)
+        assert isinstance(col, int)
+        assert isinstance(message, str)
+        assert isinstance(cls, type)

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -14,7 +14,7 @@ from flake8_inheritance.visitors import (
     ImportTracker,
     InheritanceError,
     InheritanceVisitor,
-    _collect_module_class_names,
+    collect_module_class_names,
 )
 
 
@@ -88,7 +88,7 @@ def collect_errors(
     tree = ast.parse(source)
     tracker = ImportTracker(project_package=project_package)
     tracker.visit(tree)
-    module_classes = _collect_module_class_names(tree)
+    module_classes = collect_module_class_names(tree)
     visitor = InheritanceVisitor(
         import_tracker=tracker,
         module_class_names=frozenset(module_classes),
@@ -931,13 +931,13 @@ z = [1, 2, 3]
 """
         assert collect_errors(source) == []
 
-    def test_collect_module_class_names_empty(self) -> None:
+    def testcollect_module_class_names_empty(self) -> None:
         tree = ast.parse("")
-        assert _collect_module_class_names(tree) == set()
+        assert collect_module_class_names(tree) == set()
 
-    def test_collect_module_class_names_no_classes(self) -> None:
+    def testcollect_module_class_names_no_classes(self) -> None:
         tree = ast.parse("x = 1\ndef foo(): pass\n")
-        assert _collect_module_class_names(tree) == set()
+        assert collect_module_class_names(tree) == set()
 
 
 class TestDeeplyNestedClasses:
@@ -982,7 +982,7 @@ if True:
 """
         # Note: ast.Module.body includes the if statement, but the ClassDef
         # inside it is not directly in module.body — it's in the if.body.
-        # _collect_module_class_names only scans module.body directly.
+        # collect_module_class_names only scans module.body directly.
         # However InheritanceVisitor.visit_ClassDef will still find Child
         # and check Base — which IS in module_classes.
         errors = collect_errors(source)

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -931,11 +931,11 @@ z = [1, 2, 3]
 """
         assert collect_errors(source) == []
 
-    def testcollect_module_class_names_empty(self) -> None:
+    def test_collect_module_class_names_empty(self) -> None:
         tree = ast.parse("")
         assert collect_module_class_names(tree) == set()
 
-    def testcollect_module_class_names_no_classes(self) -> None:
+    def test_collect_module_class_names_no_classes(self) -> None:
         tree = ast.parse("x = 1\ndef foo(): pass\n")
         assert collect_module_class_names(tree) == set()
 


### PR DESCRIPTION
Add tests/test_checker.py exercising INH001 (same-file and relative-import
inheritance) and INH002 (concrete methods in ABCs) through the checker's
public run() interface.  Implement checker.py so run() creates an
ImportTracker, InheritanceVisitor, and ABCPurityVisitor, walks the AST,
and yields flake8-compatible (line, col, message, type) tuples.

https://claude.ai/code/session_01UwbymBXTYBScnEFAcbpXNM