### PR TITLE
Add add_options and parse_options for --project-packages and --inh002-allowed-dunders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@ codebases.
 3. Use test-first TDD: write the failing test BEFORE the implementation
 4. All code must pass `ruff check`, `ruff format --check`, and
    `mypy --strict`
+5. Do not use `MagicMock`, monkeypatching, or equivalent monkey-patching tools
+   from pytest or other libraries; prefer interface-respecting tests without
+   brittle test doubles
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,9 @@ codebases.
 3. Use test-first TDD: write the failing test BEFORE the implementation
 4. All code must pass `ruff check`, `ruff format --check`, and
    `mypy --strict`
+5. Do not use `MagicMock`, monkeypatching, or equivalent monkey-patching tools
+   from pytest or other libraries; prefer interface-respecting tests without
+   brittle test doubles
 
 ## Architecture
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,9 @@ ignore = [
     "ISC001",  # single-line-implicit-string-concatenation (conflicts with formatter)
 ]
 
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"unittest" = { msg = "Use pytest for tests in this project." }
+
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [
     "D",       # docstring rules relaxed in tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ ignore = [
     "D",       # docstring rules relaxed in tests
     "S101",    # assert allowed in tests
     "ANN",     # annotations not required in tests
-
+    "SLF001",  # private member access allowed in tests
 ]
 
 [tool.mypy]

--- a/src/flake8_inheritance/checker.py
+++ b/src/flake8_inheritance/checker.py
@@ -13,8 +13,18 @@ from flake8_inheritance.visitors import (
 )
 
 if TYPE_CHECKING:
+    import argparse
     import ast
     from collections.abc import Generator
+
+    from flake8.options.manager import OptionManager
+
+
+def _parse_comma_separated(value: str) -> tuple[str, ...]:
+    """Split a comma-separated string into a tuple, stripping whitespace."""
+    if not value or not value.strip():
+        return ()
+    return tuple(item.strip() for item in value.split(",") if item.strip())
 
 
 class InheritanceChecker:
@@ -24,26 +34,90 @@ class InheritanceChecker:
     - ``name`` and ``version``: class-level metadata for ``flake8 --version``.
     - ``__init__(self, tree)``: receives the AST for each file.
     - ``run()``: generator yielding ``(line, col, message, type)`` tuples.
+    - ``add_options(parser)``: registers CLI/config options with flake8.
+    - ``parse_options(options)``: stores parsed option values as class attrs.
     """
 
     name: ClassVar[str] = "flake8-inheritance"
     version: ClassVar[str] = importlib.metadata.version("flake8-inheritance")
 
+    _project_packages: ClassVar[tuple[str, ...]] = ()
+    _inh002_allowed_dunders: ClassVar[tuple[str, ...]] = ("__init__",)
+
     def __init__(self, tree: ast.AST) -> None:
         """Initialize the checker with the AST for a single file."""
         self._tree = tree
 
+    @classmethod
+    def add_options(cls, parser: OptionManager) -> None:
+        """Register plugin options with flake8's option manager."""
+        parser.add_option(
+            "--project-packages",
+            default="",
+            parse_from_config=True,
+            comma_separated_list=True,
+            help="Comma-separated list of project package names to treat as internal.",
+        )
+        parser.add_option(
+            "--inh002-allowed-dunders",
+            default="__init__",
+            parse_from_config=True,
+            comma_separated_list=True,
+            help="Comma-separated list of dunder methods allowed in ABCs.",
+        )
+
+    @classmethod
+    def parse_options(cls, options: argparse.Namespace) -> None:
+        """Store parsed option values as class attributes."""
+        raw_packages = options.project_packages
+        if isinstance(raw_packages, list):
+            cls._project_packages = tuple(item.strip() for item in raw_packages if item.strip())
+        else:
+            cls._project_packages = _parse_comma_separated(raw_packages)
+
+        raw_dunders = options.inh002_allowed_dunders
+        if isinstance(raw_dunders, list):
+            cls._inh002_allowed_dunders = tuple(
+                item.strip() for item in raw_dunders if item.strip()
+            )
+        else:
+            cls._inh002_allowed_dunders = _parse_comma_separated(raw_dunders)
+
     def run(self) -> Generator[tuple[int, int, str, type], None, None]:
         """Run the checker and yield flake8 error tuples."""
-        tracker = ImportTracker()
-        tracker.visit(self._tree)
+        # Create a tracker for each configured project package
+        trackers: list[ImportTracker] = []
+        if self._project_packages:
+            for pkg in self._project_packages:
+                tracker = ImportTracker(project_package=pkg)
+                tracker.visit(self._tree)
+                trackers.append(tracker)
+        else:
+            tracker = ImportTracker()
+            tracker.visit(self._tree)
+            trackers.append(tracker)
 
         module_classes = frozenset(collect_module_class_names(self._tree))
 
-        inh_visitor = InheritanceVisitor(tracker, module_classes)
+        # Use the first tracker for primary classification; merge errors from all
+        primary_tracker = trackers[0]
+
+        inh_visitor = InheritanceVisitor(primary_tracker, module_classes)
         inh_visitor.visit(self._tree)
 
-        abc_visitor = ABCPurityVisitor(tracker)
+        # For additional project packages, run extra visitors and collect errors
+        for extra_tracker in trackers[1:]:
+            extra_visitor = InheritanceVisitor(extra_tracker, module_classes)
+            extra_visitor.visit(self._tree)
+            # Add errors not already found
+            existing = {(e.line, e.col, e.base) for e in inh_visitor.errors}
+            for error in extra_visitor.errors:
+                if (error.line, error.col, error.base) not in existing:
+                    inh_visitor.errors.append(error)
+
+        # Build allowed dunders frozenset for ABCPurityVisitor
+        allowed_dunders = frozenset(self._inh002_allowed_dunders)
+        abc_visitor = ABCPurityVisitor(primary_tracker, allowed_dunders=allowed_dunders)
         abc_visitor.visit(self._tree)
 
         checker_cls = type(self)

--- a/src/flake8_inheritance/checker.py
+++ b/src/flake8_inheritance/checker.py
@@ -42,7 +42,7 @@ class InheritanceChecker:
     version: ClassVar[str] = importlib.metadata.version("flake8-inheritance")
 
     _project_packages: ClassVar[tuple[str, ...]] = ()
-    _inh002_allowed_dunders: ClassVar[tuple[str, ...]] = ("__init__",)
+    _inh002_allowed_dunders: ClassVar[tuple[str, ...] | None] = None
 
     def __init__(self, tree: ast.AST) -> None:
         """Initialize the checker with the AST for a single file."""
@@ -60,7 +60,7 @@ class InheritanceChecker:
         )
         parser.add_option(
             "--inh002-allowed-dunders",
-            default="__init__",
+            default=None,
             parse_from_config=True,
             comma_separated_list=True,
             help="Comma-separated list of dunder methods allowed in ABCs.",
@@ -76,7 +76,9 @@ class InheritanceChecker:
             cls._project_packages = _parse_comma_separated(raw_packages)
 
         raw_dunders = options.inh002_allowed_dunders
-        if isinstance(raw_dunders, list):
+        if raw_dunders is None:
+            cls._inh002_allowed_dunders = None
+        elif isinstance(raw_dunders, list):
             cls._inh002_allowed_dunders = tuple(
                 item.strip() for item in raw_dunders if item.strip()
             )
@@ -115,8 +117,12 @@ class InheritanceChecker:
                 if (error.line, error.col, error.base) not in existing:
                     inh_visitor.errors.append(error)
 
-        # Build allowed dunders frozenset for ABCPurityVisitor
-        allowed_dunders = frozenset(self._inh002_allowed_dunders)
+        # Build allowed dunder configuration for ABCPurityVisitor
+        allowed_dunders = (
+            None
+            if self._inh002_allowed_dunders is None
+            else frozenset(self._inh002_allowed_dunders)
+        )
         abc_visitor = ABCPurityVisitor(primary_tracker, allowed_dunders=allowed_dunders)
         abc_visitor.visit(self._tree)
 

--- a/src/flake8_inheritance/visitors.py
+++ b/src/flake8_inheritance/visitors.py
@@ -194,10 +194,15 @@ class ABCPurityVisitor(ast.NodeVisitor):
     metaclass.  Dunder methods (e.g. ``__init__``) are always allowed.
     """
 
-    def __init__(self, import_tracker: ImportTracker) -> None:
+    def __init__(
+        self,
+        import_tracker: ImportTracker,
+        allowed_dunders: frozenset[str] | None = None,
+    ) -> None:
         """Initialize with a pre-populated import tracker."""
         self._tracker = import_tracker
         self.errors: list[ABCPurityError] = []
+        self._allowed_dunders = allowed_dunders
         self._abc_local_names = self._resolve_names_for("ABC")
         self._abcmeta_local_names = self._resolve_names_for("ABCMeta")
         self._abstractmethod_local_names = self._resolve_names_for("abstractmethod")
@@ -294,8 +299,11 @@ class ABCPurityVisitor(ast.NodeVisitor):
                 if not isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef):
                     continue
 
-                # Allow dunder methods
-                if item.name.startswith("__") and item.name.endswith("__"):
+                # Allow dunder methods (all if no allowlist, specific if configured)
+                is_dunder = item.name.startswith("__") and item.name.endswith("__")
+                if is_dunder and (
+                    self._allowed_dunders is None or item.name in self._allowed_dunders
+                ):
                     continue
 
                 # Check if decorated with @abstractmethod

--- a/src/flake8_inheritance/visitors.py
+++ b/src/flake8_inheritance/visitors.py
@@ -191,7 +191,8 @@ class ABCPurityVisitor(ast.NodeVisitor):
 
     Walks ``ast.ClassDef`` nodes and flags concrete (non-abstract) methods
     in classes that inherit from ``abc.ABC`` or use ``abc.ABCMeta`` as their
-    metaclass.  Dunder methods (e.g. ``__init__``) are always allowed.
+    metaclass. Dunder handling is configurable: when no allowlist is provided,
+    all dunder methods are allowed; otherwise only listed dunders are exempt.
     """
 
     def __init__(

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -60,6 +60,8 @@ class TestAddOptions:
             if call.args[0] == "--project-packages":
                 assert call.kwargs["parse_from_config"] is True
                 break
+        else:
+            pytest.fail("--project-packages was not registered")
 
     def test_inh002_allowed_dunders_parse_from_config(self) -> None:
         """--inh002-allowed-dunders has parse_from_config=True."""
@@ -71,6 +73,8 @@ class TestAddOptions:
             if call.args[0] == "--inh002-allowed-dunders":
                 assert call.kwargs["parse_from_config"] is True
                 break
+        else:
+            pytest.fail("--inh002-allowed-dunders was not registered")
 
     def test_project_packages_default_empty(self) -> None:
         """--project-packages defaults to empty string."""
@@ -82,17 +86,21 @@ class TestAddOptions:
             if call.args[0] == "--project-packages":
                 assert call.kwargs["default"] == ""
                 break
+        else:
+            pytest.fail("--project-packages was not registered")
 
-    def test_inh002_allowed_dunders_default_init(self) -> None:
-        """--inh002-allowed-dunders defaults to '__init__'."""
+    def test_inh002_allowed_dunders_default_none(self) -> None:
+        """--inh002-allowed-dunders defaults to None (all dunders allowed)."""
         parser = _ParserSpy()
         InheritanceChecker.add_options(parser)
 
         calls = parser.calls
         for call in calls:
             if call.args[0] == "--inh002-allowed-dunders":
-                assert call.kwargs["default"] == "__init__"
+                assert call.kwargs["default"] is None
                 break
+        else:
+            pytest.fail("--inh002-allowed-dunders was not registered")
 
 
 class TestParseOptions:
@@ -182,7 +190,7 @@ class TestOptionsIntegration:
         yield
         # Reset to defaults
         InheritanceChecker._project_packages = ()
-        InheritanceChecker._inh002_allowed_dunders = ("__init__",)
+        InheritanceChecker._inh002_allowed_dunders = None
 
     def test_project_packages_flags_absolute_import(self) -> None:
         """With --project-packages set, absolute imports from that package trigger INH001."""
@@ -220,9 +228,9 @@ class TestOptionsIntegration:
 
         assert results == []
 
-    def test_allowed_dunders_init_allowed_by_default(self) -> None:
-        """__init__ is allowed in ABCs by default."""
-        options = argparse.Namespace(project_packages="", inh002_allowed_dunders="__init__")
+    def test_allowed_dunders_all_allowed_by_default(self) -> None:
+        """Without config, dunder methods in ABCs are all allowed."""
+        options = argparse.Namespace(project_packages="", inh002_allowed_dunders=None)
         InheritanceChecker.parse_options(options)
 
         source = """\
@@ -231,6 +239,9 @@ class TestOptionsIntegration:
             class MyABC(ABC):
                 def __init__(self):
                     self.x = 1
+
+                def __repr__(self):
+                    return "MyABC"
 
                 @abstractmethod
                 def do_something(self):
@@ -295,3 +306,10 @@ class TestOptionsIntegration:
         # __init__ and __repr__ allowed, __str__ flagged
         assert len(results) == 1
         assert "__str__" in results[0][2]
+
+    def test_missing_allowed_dunders_uses_none(self) -> None:
+        """None keeps default behavior (all dunders allowed)."""
+        options = argparse.Namespace(project_packages="", inh002_allowed_dunders=None)
+        InheritanceChecker.parse_options(options)
+
+        assert InheritanceChecker._inh002_allowed_dunders is None

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -6,7 +6,6 @@ import argparse
 import ast
 import textwrap
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -16,33 +15,47 @@ import pytest
 from flake8_inheritance.checker import InheritanceChecker
 
 
+class _OptionCall:
+    def __init__(self, *args: str, **kwargs: object) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+
+class _ParserSpy:
+    def __init__(self) -> None:
+        self.calls: list[_OptionCall] = []
+
+    def add_option(self, *args: str, **kwargs: object) -> None:
+        self.calls.append(_OptionCall(*args, **kwargs))
+
+
 class TestAddOptions:
     """add_options registers CLI options with flake8's option_manager."""
 
     def test_registers_project_packages(self) -> None:
         """--project-packages is registered as a comma-separated option."""
-        parser = MagicMock()
+        parser = _ParserSpy()
         InheritanceChecker.add_options(parser)
 
-        calls = parser.add_option.call_args_list
+        calls = parser.calls
         long_names = [call.args[0] for call in calls]
         assert "--project-packages" in long_names
 
     def test_registers_inh002_allowed_dunders(self) -> None:
         """--inh002-allowed-dunders is registered as a comma-separated option."""
-        parser = MagicMock()
+        parser = _ParserSpy()
         InheritanceChecker.add_options(parser)
 
-        calls = parser.add_option.call_args_list
+        calls = parser.calls
         long_names = [call.args[0] for call in calls]
         assert "--inh002-allowed-dunders" in long_names
 
     def test_project_packages_parse_from_config(self) -> None:
         """--project-packages has parse_from_config=True."""
-        parser = MagicMock()
+        parser = _ParserSpy()
         InheritanceChecker.add_options(parser)
 
-        calls = parser.add_option.call_args_list
+        calls = parser.calls
         for call in calls:
             if call.args[0] == "--project-packages":
                 assert call.kwargs["parse_from_config"] is True
@@ -50,10 +63,10 @@ class TestAddOptions:
 
     def test_inh002_allowed_dunders_parse_from_config(self) -> None:
         """--inh002-allowed-dunders has parse_from_config=True."""
-        parser = MagicMock()
+        parser = _ParserSpy()
         InheritanceChecker.add_options(parser)
 
-        calls = parser.add_option.call_args_list
+        calls = parser.calls
         for call in calls:
             if call.args[0] == "--inh002-allowed-dunders":
                 assert call.kwargs["parse_from_config"] is True
@@ -61,10 +74,10 @@ class TestAddOptions:
 
     def test_project_packages_default_empty(self) -> None:
         """--project-packages defaults to empty string."""
-        parser = MagicMock()
+        parser = _ParserSpy()
         InheritanceChecker.add_options(parser)
 
-        calls = parser.add_option.call_args_list
+        calls = parser.calls
         for call in calls:
             if call.args[0] == "--project-packages":
                 assert call.kwargs["default"] == ""
@@ -72,10 +85,10 @@ class TestAddOptions:
 
     def test_inh002_allowed_dunders_default_init(self) -> None:
         """--inh002-allowed-dunders defaults to '__init__'."""
-        parser = MagicMock()
+        parser = _ParserSpy()
         InheritanceChecker.add_options(parser)
 
-        calls = parser.add_option.call_args_list
+        calls = parser.calls
         for call in calls:
             if call.args[0] == "--inh002-allowed-dunders":
                 assert call.kwargs["default"] == "__init__"
@@ -130,9 +143,7 @@ class TestParseOptions:
 
     def test_single_allowed_dunder(self) -> None:
         """A single dunder is parsed into a one-element tuple."""
-        options = argparse.Namespace(
-            project_packages="", inh002_allowed_dunders="__init__"
-        )
+        options = argparse.Namespace(project_packages="", inh002_allowed_dunders="__init__")
         InheritanceChecker.parse_options(options)
 
         assert InheritanceChecker._inh002_allowed_dunders == ("__init__",)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,0 +1,286 @@
+"""Tests for InheritanceChecker.add_options and parse_options."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import textwrap
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+import pytest
+
+from flake8_inheritance.checker import InheritanceChecker
+
+
+class TestAddOptions:
+    """add_options registers CLI options with flake8's option_manager."""
+
+    def test_registers_project_packages(self) -> None:
+        """--project-packages is registered as a comma-separated option."""
+        parser = MagicMock()
+        InheritanceChecker.add_options(parser)
+
+        calls = parser.add_option.call_args_list
+        long_names = [call.args[0] for call in calls]
+        assert "--project-packages" in long_names
+
+    def test_registers_inh002_allowed_dunders(self) -> None:
+        """--inh002-allowed-dunders is registered as a comma-separated option."""
+        parser = MagicMock()
+        InheritanceChecker.add_options(parser)
+
+        calls = parser.add_option.call_args_list
+        long_names = [call.args[0] for call in calls]
+        assert "--inh002-allowed-dunders" in long_names
+
+    def test_project_packages_parse_from_config(self) -> None:
+        """--project-packages has parse_from_config=True."""
+        parser = MagicMock()
+        InheritanceChecker.add_options(parser)
+
+        calls = parser.add_option.call_args_list
+        for call in calls:
+            if call.args[0] == "--project-packages":
+                assert call.kwargs["parse_from_config"] is True
+                break
+
+    def test_inh002_allowed_dunders_parse_from_config(self) -> None:
+        """--inh002-allowed-dunders has parse_from_config=True."""
+        parser = MagicMock()
+        InheritanceChecker.add_options(parser)
+
+        calls = parser.add_option.call_args_list
+        for call in calls:
+            if call.args[0] == "--inh002-allowed-dunders":
+                assert call.kwargs["parse_from_config"] is True
+                break
+
+    def test_project_packages_default_empty(self) -> None:
+        """--project-packages defaults to empty string."""
+        parser = MagicMock()
+        InheritanceChecker.add_options(parser)
+
+        calls = parser.add_option.call_args_list
+        for call in calls:
+            if call.args[0] == "--project-packages":
+                assert call.kwargs["default"] == ""
+                break
+
+    def test_inh002_allowed_dunders_default_init(self) -> None:
+        """--inh002-allowed-dunders defaults to '__init__'."""
+        parser = MagicMock()
+        InheritanceChecker.add_options(parser)
+
+        calls = parser.add_option.call_args_list
+        for call in calls:
+            if call.args[0] == "--inh002-allowed-dunders":
+                assert call.kwargs["default"] == "__init__"
+                break
+
+
+class TestParseOptions:
+    """parse_options stores parsed values as class attributes."""
+
+    def test_empty_project_packages(self) -> None:
+        """Empty string results in an empty tuple."""
+        options = argparse.Namespace(project_packages="", inh002_allowed_dunders="__init__")
+        InheritanceChecker.parse_options(options)
+
+        assert InheritanceChecker._project_packages == ()
+
+    def test_single_project_package(self) -> None:
+        """A single value is parsed into a one-element tuple."""
+        options = argparse.Namespace(
+            project_packages="myproject", inh002_allowed_dunders="__init__"
+        )
+        InheritanceChecker.parse_options(options)
+
+        assert InheritanceChecker._project_packages == ("myproject",)
+
+    def test_multiple_project_packages(self) -> None:
+        """Comma-separated values are split into a tuple."""
+        options = argparse.Namespace(
+            project_packages="myproject,otherlib,utils",
+            inh002_allowed_dunders="__init__",
+        )
+        InheritanceChecker.parse_options(options)
+
+        assert InheritanceChecker._project_packages == ("myproject", "otherlib", "utils")
+
+    def test_project_packages_strips_whitespace(self) -> None:
+        """Whitespace around values is stripped."""
+        options = argparse.Namespace(
+            project_packages="  myproject , otherlib  ",
+            inh002_allowed_dunders="__init__",
+        )
+        InheritanceChecker.parse_options(options)
+
+        assert InheritanceChecker._project_packages == ("myproject", "otherlib")
+
+    def test_empty_allowed_dunders(self) -> None:
+        """Empty string results in an empty tuple."""
+        options = argparse.Namespace(project_packages="", inh002_allowed_dunders="")
+        InheritanceChecker.parse_options(options)
+
+        assert InheritanceChecker._inh002_allowed_dunders == ()
+
+    def test_single_allowed_dunder(self) -> None:
+        """A single dunder is parsed into a one-element tuple."""
+        options = argparse.Namespace(
+            project_packages="", inh002_allowed_dunders="__init__"
+        )
+        InheritanceChecker.parse_options(options)
+
+        assert InheritanceChecker._inh002_allowed_dunders == ("__init__",)
+
+    def test_multiple_allowed_dunders(self) -> None:
+        """Comma-separated dunders are split into a tuple."""
+        options = argparse.Namespace(
+            project_packages="",
+            inh002_allowed_dunders="__init__,__new__,__post_init__",
+        )
+        InheritanceChecker.parse_options(options)
+
+        assert InheritanceChecker._inh002_allowed_dunders == (
+            "__init__",
+            "__new__",
+            "__post_init__",
+        )
+
+    def test_allowed_dunders_strips_whitespace(self) -> None:
+        """Whitespace around values is stripped."""
+        options = argparse.Namespace(
+            project_packages="",
+            inh002_allowed_dunders="  __init__ , __new__  ",
+        )
+        InheritanceChecker.parse_options(options)
+
+        assert InheritanceChecker._inh002_allowed_dunders == ("__init__", "__new__")
+
+
+class TestOptionsIntegration:
+    """Options affect checker behavior through run()."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_class_attrs(self) -> Iterator[None]:
+        """Reset class-level option attributes after each test."""
+        yield
+        # Reset to defaults
+        InheritanceChecker._project_packages = ()
+        InheritanceChecker._inh002_allowed_dunders = ("__init__",)
+
+    def test_project_packages_flags_absolute_import(self) -> None:
+        """With --project-packages set, absolute imports from that package trigger INH001."""
+        options = argparse.Namespace(
+            project_packages="myproject", inh002_allowed_dunders="__init__"
+        )
+        InheritanceChecker.parse_options(options)
+
+        source = """\
+            from myproject.models import Base
+
+            class Child(Base):
+                pass
+        """
+        tree = ast.parse(textwrap.dedent(source))
+        results = list(InheritanceChecker(tree).run())
+
+        assert len(results) == 1
+        assert "INH001" in results[0][2]
+        assert "Base" in results[0][2]
+
+    def test_no_project_packages_allows_absolute_import(self) -> None:
+        """Without --project-packages, absolute imports are not flagged."""
+        options = argparse.Namespace(project_packages="", inh002_allowed_dunders="__init__")
+        InheritanceChecker.parse_options(options)
+
+        source = """\
+            from myproject.models import Base
+
+            class Child(Base):
+                pass
+        """
+        tree = ast.parse(textwrap.dedent(source))
+        results = list(InheritanceChecker(tree).run())
+
+        assert results == []
+
+    def test_allowed_dunders_init_allowed_by_default(self) -> None:
+        """__init__ is allowed in ABCs by default."""
+        options = argparse.Namespace(project_packages="", inh002_allowed_dunders="__init__")
+        InheritanceChecker.parse_options(options)
+
+        source = """\
+            from abc import ABC, abstractmethod
+
+            class MyABC(ABC):
+                def __init__(self):
+                    self.x = 1
+
+                @abstractmethod
+                def do_something(self):
+                    pass
+        """
+        tree = ast.parse(textwrap.dedent(source))
+        results = list(InheritanceChecker(tree).run())
+
+        assert results == []
+
+    def test_allowed_dunders_empty_flags_all_dunders(self) -> None:
+        """With empty allowed-dunders, concrete dunders in ABCs trigger INH002."""
+        options = argparse.Namespace(project_packages="", inh002_allowed_dunders="")
+        InheritanceChecker.parse_options(options)
+
+        source = """\
+            from abc import ABC, abstractmethod
+
+            class MyABC(ABC):
+                def __init__(self):
+                    self.x = 1
+
+                @abstractmethod
+                def do_something(self):
+                    pass
+        """
+        tree = ast.parse(textwrap.dedent(source))
+        results = list(InheritanceChecker(tree).run())
+
+        assert len(results) == 1
+        assert "INH002" in results[0][2]
+        assert "__init__" in results[0][2]
+
+    def test_allowed_dunders_custom_list(self) -> None:
+        """Custom allowed-dunders list controls which dunders are exempt."""
+        options = argparse.Namespace(
+            project_packages="",
+            inh002_allowed_dunders="__init__,__repr__",
+        )
+        InheritanceChecker.parse_options(options)
+
+        source = """\
+            from abc import ABC, abstractmethod
+
+            class MyABC(ABC):
+                def __init__(self):
+                    self.x = 1
+
+                def __repr__(self):
+                    return "MyABC"
+
+                def __str__(self):
+                    return "abc"
+
+                @abstractmethod
+                def do_something(self):
+                    pass
+        """
+        tree = ast.parse(textwrap.dedent(source))
+        results = list(InheritanceChecker(tree).run())
+
+        # __init__ and __repr__ allowed, __str__ flagged
+        assert len(results) == 1
+        assert "__str__" in results[0][2]


### PR DESCRIPTION
Implement flake8 option hooks (TDD) so users can configure which packages
are treated as internal (INH001) and which dunder methods are allowed in
ABCs (INH002).  Both options support comma-separated values and
parse_from_config for .flake8/.cfg files.

https://claude.ai/code/session_01TmNabVJzhUKZ4Yy251k4je