### PR TITLE
Fix INH002 default behavior regression and tighten option registration tests

### DIFF
--- a/src/flake8_inheritance/checker.py
+++ b/src/flake8_inheritance/checker.py
@@ -42,7 +42,7 @@ class InheritanceChecker:
     version: ClassVar[str] = importlib.metadata.version("flake8-inheritance")
 
     _project_packages: ClassVar[tuple[str, ...]] = ()
-    _inh002_allowed_dunders: ClassVar[tuple[str, ...]] = ("__init__",)
+    _inh002_allowed_dunders: ClassVar[tuple[str, ...] | None] = None
 
     def __init__(self, tree: ast.AST) -> None:
         """Initialize the checker with the AST for a single file."""
@@ -60,7 +60,7 @@ class InheritanceChecker:
         )
         parser.add_option(
             "--inh002-allowed-dunders",
-            default="__init__",
+            default=None,
             parse_from_config=True,
             comma_separated_list=True,
             help="Comma-separated list of dunder methods allowed in ABCs.",
@@ -76,7 +76,9 @@ class InheritanceChecker:
             cls._project_packages = _parse_comma_separated(raw_packages)
 
         raw_dunders = options.inh002_allowed_dunders
-        if isinstance(raw_dunders, list):
+        if raw_dunders is None:
+            cls._inh002_allowed_dunders = None
+        elif isinstance(raw_dunders, list):
             cls._inh002_allowed_dunders = tuple(
                 item.strip() for item in raw_dunders if item.strip()
             )
@@ -115,8 +117,12 @@ class InheritanceChecker:
                 if (error.line, error.col, error.base) not in existing:
                     inh_visitor.errors.append(error)
 
-        # Build allowed dunders frozenset for ABCPurityVisitor
-        allowed_dunders = frozenset(self._inh002_allowed_dunders)
+        # Build allowed dunder configuration for ABCPurityVisitor
+        allowed_dunders = (
+            None
+            if self._inh002_allowed_dunders is None
+            else frozenset(self._inh002_allowed_dunders)
+        )
         abc_visitor = ABCPurityVisitor(primary_tracker, allowed_dunders=allowed_dunders)
         abc_visitor.visit(self._tree)
 

--- a/src/flake8_inheritance/visitors.py
+++ b/src/flake8_inheritance/visitors.py
@@ -191,7 +191,8 @@ class ABCPurityVisitor(ast.NodeVisitor):
 
     Walks ``ast.ClassDef`` nodes and flags concrete (non-abstract) methods
     in classes that inherit from ``abc.ABC`` or use ``abc.ABCMeta`` as their
-    metaclass.  Dunder methods (e.g. ``__init__``) are always allowed.
+    metaclass. Dunder handling is configurable: when no allowlist is provided,
+    all dunder methods are allowed; otherwise only listed dunders are exempt.
     """
 
     def __init__(

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -60,6 +60,8 @@ class TestAddOptions:
             if call.args[0] == "--project-packages":
                 assert call.kwargs["parse_from_config"] is True
                 break
+        else:
+            pytest.fail("--project-packages was not registered")
 
     def test_inh002_allowed_dunders_parse_from_config(self) -> None:
         """--inh002-allowed-dunders has parse_from_config=True."""
@@ -71,6 +73,8 @@ class TestAddOptions:
             if call.args[0] == "--inh002-allowed-dunders":
                 assert call.kwargs["parse_from_config"] is True
                 break
+        else:
+            pytest.fail("--inh002-allowed-dunders was not registered")
 
     def test_project_packages_default_empty(self) -> None:
         """--project-packages defaults to empty string."""
@@ -82,17 +86,21 @@ class TestAddOptions:
             if call.args[0] == "--project-packages":
                 assert call.kwargs["default"] == ""
                 break
+        else:
+            pytest.fail("--project-packages was not registered")
 
-    def test_inh002_allowed_dunders_default_init(self) -> None:
-        """--inh002-allowed-dunders defaults to '__init__'."""
+    def test_inh002_allowed_dunders_default_none(self) -> None:
+        """--inh002-allowed-dunders defaults to None (all dunders allowed)."""
         parser = _ParserSpy()
         InheritanceChecker.add_options(parser)
 
         calls = parser.calls
         for call in calls:
             if call.args[0] == "--inh002-allowed-dunders":
-                assert call.kwargs["default"] == "__init__"
+                assert call.kwargs["default"] is None
                 break
+        else:
+            pytest.fail("--inh002-allowed-dunders was not registered")
 
 
 class TestParseOptions:
@@ -182,7 +190,7 @@ class TestOptionsIntegration:
         yield
         # Reset to defaults
         InheritanceChecker._project_packages = ()
-        InheritanceChecker._inh002_allowed_dunders = ("__init__",)
+        InheritanceChecker._inh002_allowed_dunders = None
 
     def test_project_packages_flags_absolute_import(self) -> None:
         """With --project-packages set, absolute imports from that package trigger INH001."""
@@ -220,9 +228,9 @@ class TestOptionsIntegration:
 
         assert results == []
 
-    def test_allowed_dunders_init_allowed_by_default(self) -> None:
-        """__init__ is allowed in ABCs by default."""
-        options = argparse.Namespace(project_packages="", inh002_allowed_dunders="__init__")
+    def test_allowed_dunders_all_allowed_by_default(self) -> None:
+        """Without config, dunder methods in ABCs are all allowed."""
+        options = argparse.Namespace(project_packages="", inh002_allowed_dunders=None)
         InheritanceChecker.parse_options(options)
 
         source = """\
@@ -231,6 +239,9 @@ class TestOptionsIntegration:
             class MyABC(ABC):
                 def __init__(self):
                     self.x = 1
+
+                def __repr__(self):
+                    return "MyABC"
 
                 @abstractmethod
                 def do_something(self):
@@ -295,3 +306,10 @@ class TestOptionsIntegration:
         # __init__ and __repr__ allowed, __str__ flagged
         assert len(results) == 1
         assert "__str__" in results[0][2]
+
+    def test_missing_allowed_dunders_uses_none(self) -> None:
+        """None keeps default behavior (all dunders allowed)."""
+        options = argparse.Namespace(project_packages="", inh002_allowed_dunders=None)
+        InheritanceChecker.parse_options(options)
+
+        assert InheritanceChecker._inh002_allowed_dunders is None


### PR DESCRIPTION
### Motivation
- Option-registration tests could silently pass when the expected option was not registered because the loop `break`ed only on match; this made missing options escape detection.
- The INH002 visitor behavior regressed to a stricter default (`"__init__"` only) which changes out-of-the-box behavior and differs between invoking the visitor directly versus via the checker.
- The `ABCPurityVisitor` docstring no longer matched the actual configurable dunder semantics and needed clarification.

### Description
- Hardened option registration tests in `tests/test_options.py` by adding explicit `else: pytest.fail(...)` branches so missing option registrations fail deterministically, and updated expectations to match the intended defaults.
- Restored backward-compatible INH002 semantics by making the checker's class-level `_inh002_allowed_dunders` default `None` (meaning allow all dunders when not configured) and by setting the `--inh002-allowed-dunders` option default to `None` in `InheritanceChecker.add_options()`.
- Updated `InheritanceChecker.parse_options()` to accept `None`, lists, and comma-separated strings for `inh002_allowed_dunders`, preserving `None` to express the allow-all behavior.
- Adjusted `InheritanceChecker.run()` to pass either `None` or a `frozenset` to `ABCPurityVisitor` so the visitor observes the intended semantics.
- Clarified `ABCPurityVisitor` class docstring in `src/flake8_inheritance/visitors.py` to state that dunder handling is configurable (no allowlist = all dunders allowed; explicit allowlist limits exemptions).
- Files changed: `src/flake8_inheritance/checker.py`, `src/flake8_inheritance/visitors.py`, and `tests/test_options.py`.

### Testing
- Ran `uv run pre-commit run --all-files`, which completed successfully (formatting, ruff, mypy and all pre-commit checks passed).
- Ran `uv run pytest`, which passed (129 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698af64c1b008326afbd1910b87fb860)