### PR TITLE
Add integration tests using pytest-flake8-path

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,127 @@
+"""Integration tests using pytest-flake8-path to exercise the full flake8 pipeline."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+from pytest_flake8_path import Flake8Path
+
+
+def test_plugin_loaded(flake8_path: Flake8Path) -> None:
+    """Plugin appears in ``flake8 --version`` output."""
+    result = subprocess.run(
+        [sys.executable, "-m", "flake8", "--version"],
+        capture_output=True,
+        text=True,
+        cwd=str(flake8_path),
+    )
+    assert "flake8-inheritance" in result.stdout
+
+
+def test_inh001_with_config(flake8_path: Flake8Path) -> None:
+    """Configured project package triggers INH001."""
+    (flake8_path / "setup.cfg").write_text(
+        textwrap.dedent("""\
+            [flake8]
+            project_packages = myproject
+        """)
+    )
+    (flake8_path / "example.py").write_text(
+        textwrap.dedent("""\
+            from myproject.models import Base
+
+            class Child(Base):
+                pass
+        """)
+    )
+    result = flake8_path.run_flake8()
+    assert result.exit_code != 0
+    assert any("INH001" in line for line in result.out_lines)
+    assert any("Base" in line for line in result.out_lines)
+
+
+def test_no_false_positive_on_external(flake8_path: Flake8Path) -> None:
+    """Pydantic BaseModel is not flagged (external dependency)."""
+    (flake8_path / "example.py").write_text(
+        textwrap.dedent("""\
+            from pydantic import BaseModel
+
+            class User(BaseModel):
+                name: str
+        """)
+    )
+    result = flake8_path.run_flake8()
+    inh_lines = [line for line in result.out_lines if "INH" in line]
+    assert inh_lines == []
+
+
+def test_inh002_concrete_method(flake8_path: Flake8Path) -> None:
+    """Concrete method in ABC triggers INH002."""
+    (flake8_path / "example.py").write_text(
+        textwrap.dedent("""\
+            from abc import ABC, abstractmethod
+
+            class MyABC(ABC):
+                @abstractmethod
+                def required(self):
+                    pass
+
+                def helper(self):
+                    return 42
+        """)
+    )
+    result = flake8_path.run_flake8()
+    assert result.exit_code != 0
+    assert any("INH002" in line for line in result.out_lines)
+    assert any("MyABC" in line for line in result.out_lines)
+    assert any("helper" in line for line in result.out_lines)
+
+
+def test_noqa_suppression(flake8_path: Flake8Path) -> None:
+    """``# noqa: INH001`` suppresses the violation."""
+    (flake8_path / "example.py").write_text(
+        textwrap.dedent("""\
+            class Base:
+                pass
+
+            class Child(Base):  # noqa: INH001
+                pass
+        """)
+    )
+    result = flake8_path.run_flake8()
+    inh_lines = [line for line in result.out_lines if "INH001" in line]
+    assert inh_lines == []
+
+
+def test_zero_config_same_file(flake8_path: Flake8Path) -> None:
+    """Same-file inheritance is flagged without any configuration."""
+    (flake8_path / "example.py").write_text(
+        textwrap.dedent("""\
+            class Base:
+                pass
+
+            class Child(Base):
+                pass
+        """)
+    )
+    result = flake8_path.run_flake8()
+    assert result.exit_code != 0
+    assert any("INH001" in line for line in result.out_lines)
+    assert any("Base" in line for line in result.out_lines)
+
+
+def test_zero_config_absolute_import(flake8_path: Flake8Path) -> None:
+    """Absolute import with no ``--project-packages`` produces no INH error."""
+    (flake8_path / "example.py").write_text(
+        textwrap.dedent("""\
+            from myproject.models import Base
+
+            class Child(Base):
+                pass
+        """)
+    )
+    result = flake8_path.run_flake8()
+    inh_lines = [line for line in result.out_lines if "INH" in line]
+    assert inh_lines == []

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,22 +2,17 @@
 
 from __future__ import annotations
 
-import subprocess
-import sys
 import textwrap
+from typing import TYPE_CHECKING
 
-from pytest_flake8_path import Flake8Path
+if TYPE_CHECKING:
+    from pytest_flake8_path import Flake8Path
 
 
 def test_plugin_loaded(flake8_path: Flake8Path) -> None:
     """Plugin appears in ``flake8 --version`` output."""
-    result = subprocess.run(
-        [sys.executable, "-m", "flake8", "--version"],
-        capture_output=True,
-        text=True,
-        cwd=str(flake8_path),
-    )
-    assert "flake8-inheritance" in result.stdout
+    result = flake8_path.run_flake8(extra_args=["--version"])
+    assert "flake8-inheritance" in result.out
 
 
 def test_inh001_with_config(flake8_path: Flake8Path) -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,6 +8,16 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pytest_flake8_path import Flake8Path
 
+# Every test uses ``--select=INH`` (via setup.cfg or extra_args) so that only
+# this plugin's codes are active.  This isolates the assertions from unrelated
+# pycodestyle / pyflakes diagnostics and lets us rely on ``exit_code == 0`` to
+# confirm a genuinely clean run.
+
+_FLAKE8_SELECT_INH = """\
+[flake8]
+select = INH
+"""
+
 
 def test_plugin_loaded(flake8_path: Flake8Path) -> None:
     """Plugin appears in ``flake8 --version`` output."""
@@ -20,7 +30,8 @@ def test_inh001_with_config(flake8_path: Flake8Path) -> None:
     (flake8_path / "setup.cfg").write_text(
         textwrap.dedent("""\
             [flake8]
-            project_packages = myproject
+            select = INH
+            project-packages = myproject
         """)
     )
     (flake8_path / "example.py").write_text(
@@ -39,6 +50,7 @@ def test_inh001_with_config(flake8_path: Flake8Path) -> None:
 
 def test_no_false_positive_on_external(flake8_path: Flake8Path) -> None:
     """Pydantic BaseModel is not flagged (external dependency)."""
+    (flake8_path / "setup.cfg").write_text(_FLAKE8_SELECT_INH)
     (flake8_path / "example.py").write_text(
         textwrap.dedent("""\
             from pydantic import BaseModel
@@ -48,12 +60,13 @@ def test_no_false_positive_on_external(flake8_path: Flake8Path) -> None:
         """)
     )
     result = flake8_path.run_flake8()
-    inh_lines = [line for line in result.out_lines if "INH" in line]
-    assert inh_lines == []
+    assert result.exit_code == 0
+    assert result.out_lines == []
 
 
 def test_inh002_concrete_method(flake8_path: Flake8Path) -> None:
     """Concrete method in ABC triggers INH002."""
+    (flake8_path / "setup.cfg").write_text(_FLAKE8_SELECT_INH)
     (flake8_path / "example.py").write_text(
         textwrap.dedent("""\
             from abc import ABC, abstractmethod
@@ -76,6 +89,7 @@ def test_inh002_concrete_method(flake8_path: Flake8Path) -> None:
 
 def test_noqa_suppression(flake8_path: Flake8Path) -> None:
     """``# noqa: INH001`` suppresses the violation."""
+    (flake8_path / "setup.cfg").write_text(_FLAKE8_SELECT_INH)
     (flake8_path / "example.py").write_text(
         textwrap.dedent("""\
             class Base:
@@ -86,12 +100,13 @@ def test_noqa_suppression(flake8_path: Flake8Path) -> None:
         """)
     )
     result = flake8_path.run_flake8()
-    inh_lines = [line for line in result.out_lines if "INH001" in line]
-    assert inh_lines == []
+    assert result.exit_code == 0
+    assert result.out_lines == []
 
 
 def test_zero_config_same_file(flake8_path: Flake8Path) -> None:
     """Same-file inheritance is flagged without any configuration."""
+    (flake8_path / "setup.cfg").write_text(_FLAKE8_SELECT_INH)
     (flake8_path / "example.py").write_text(
         textwrap.dedent("""\
             class Base:
@@ -109,6 +124,7 @@ def test_zero_config_same_file(flake8_path: Flake8Path) -> None:
 
 def test_zero_config_absolute_import(flake8_path: Flake8Path) -> None:
     """Absolute import with no ``--project-packages`` produces no INH error."""
+    (flake8_path / "setup.cfg").write_text(_FLAKE8_SELECT_INH)
     (flake8_path / "example.py").write_text(
         textwrap.dedent("""\
             from myproject.models import Base
@@ -118,5 +134,5 @@ def test_zero_config_absolute_import(flake8_path: Flake8Path) -> None:
         """)
     )
     result = flake8_path.run_flake8()
-    inh_lines = [line for line in result.out_lines if "INH" in line]
-    assert inh_lines == []
+    assert result.exit_code == 0
+    assert result.out_lines == []


### PR DESCRIPTION
Exercise the full flake8 pipeline with 7 integration tests:
- plugin loaded in flake8 --version
- INH001 triggered with --project-packages config
- no false positive on external imports (pydantic)
- INH002 on concrete method in ABC
- noqa: INH001 suppression
- zero-config same-file inheritance detection
- zero-config absolute import produces no error

https://claude.ai/code/session_01PCC6hE8SBsfZQXGXfs2LRc