### PR TITLE
Add test fixture files and refactor tests to use them

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ ignore = [
     "ANN",     # annotations not required in tests
     "SLF001",  # private member access allowed in tests
 ]
+"tests/fixtures/**/*.py" = [
+    "ALL",     # fixtures are sample code, not production — skip all lint rules
+]
 
 [tool.mypy]
 python_version = "3.11"
@@ -111,6 +114,10 @@ show_error_codes = true
 [[tool.mypy.overrides]]
 module = "flake8.*"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "tests.fixtures.*"
+ignore_errors = true
 
 [tool.codespell]
 ignore-words-list = "INH"

--- a/tests/fixtures/dynamic_bases.py
+++ b/tests/fixtures/dynamic_bases.py
@@ -1,0 +1,11 @@
+"""Fixture: dynamic base classes (function calls as bases)."""
+
+
+def get_base():
+    return type("DynBase", (), {})
+
+
+class DynamicChild(get_base()):
+    """Dynamic base — should be silently skipped."""
+
+    pass

--- a/tests/fixtures/external_inheritance.py
+++ b/tests/fixtures/external_inheritance.py
@@ -1,0 +1,18 @@
+"""Fixture: inheritance from external / stdlib bases (no INH001 expected)."""
+
+from collections import OrderedDict
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class MyDict(OrderedDict):
+    """Stdlib base — allowed."""
+
+    pass
+
+
+class MyGeneric(Generic[T]):
+    """Stdlib generic — allowed."""
+
+    pass

--- a/tests/fixtures/import_aliases.py
+++ b/tests/fixtures/import_aliases.py
@@ -1,0 +1,14 @@
+"""Fixture: aliased imports."""
+
+from abc import ABC as AbstractBase
+from abc import abstractmethod as am
+
+
+class AliasedABC(AbstractBase):
+    @am
+    def do_thing(self):
+        pass
+
+    def concrete_helper(self):
+        """INH002: concrete method in aliased ABC."""
+        return 42

--- a/tests/fixtures/impure_abc.py
+++ b/tests/fixtures/impure_abc.py
@@ -1,0 +1,17 @@
+"""Fixture: ABC with concrete methods (should trigger INH002)."""
+
+from abc import ABC, abstractmethod
+
+
+class ImpureABC(ABC):
+    @abstractmethod
+    def required(self):
+        pass
+
+    def helper(self):
+        """INH002: concrete method in ABC."""
+        return 42
+
+    def another_helper(self):
+        """INH002: another concrete method."""
+        return "hello"

--- a/tests/fixtures/internal_inheritance.py
+++ b/tests/fixtures/internal_inheritance.py
@@ -1,0 +1,29 @@
+"""Fixture: same-file and project-package inheritance (should trigger INH001)."""
+
+from myproject.models import Model
+
+
+class Base:
+    pass
+
+
+class Mixin:
+    pass
+
+
+class ChildOfSameFile(Base):
+    """INH001: inherits from same-file class."""
+
+    pass
+
+
+class MultipleInternalBases(Base, Mixin):
+    """INH001 x2: inherits from two same-file classes."""
+
+    pass
+
+
+class ChildOfProjectPackage(Model):
+    """INH001: inherits from project-package class (when myproject is configured)."""
+
+    pass

--- a/tests/fixtures/mixed_bases.py
+++ b/tests/fixtures/mixed_bases.py
@@ -1,0 +1,11 @@
+"""Fixture: class with both internal and external bases."""
+
+from collections import OrderedDict
+
+from .models import InternalBase
+
+
+class MixedChild(InternalBase, OrderedDict):
+    """INH001 for InternalBase only; OrderedDict is stdlib."""
+
+    pass

--- a/tests/fixtures/mixed_bases.py
+++ b/tests/fixtures/mixed_bases.py
@@ -8,4 +8,5 @@ from .models import InternalBase
 class MixedChild(InternalBase, OrderedDict):
     """INH001 for InternalBase only; OrderedDict is stdlib."""
 
-    pass
+    def __init__(self, *args, **kwargs) -> None:
+        OrderedDict.__init__(self, *args, **kwargs)

--- a/tests/fixtures/no_classes.py
+++ b/tests/fixtures/no_classes.py
@@ -1,0 +1,18 @@
+"""Fixture: imports and functions only — no class definitions."""
+
+import os
+from collections import OrderedDict
+
+CONSTANT = 42
+
+
+def helper(x):
+    return x + 1
+
+
+def get_path():
+    return os.getcwd()
+
+
+def make_dict():
+    return OrderedDict()

--- a/tests/fixtures/pure_abc.py
+++ b/tests/fixtures/pure_abc.py
@@ -1,0 +1,13 @@
+"""Fixture: ABC with only abstract methods (no INH002 expected)."""
+
+from abc import ABC, abstractmethod
+
+
+class PureInterface(ABC):
+    @abstractmethod
+    def process(self):
+        pass
+
+    @abstractmethod
+    def validate(self):
+        pass

--- a/tests/fixtures/star_imports.py
+++ b/tests/fixtures/star_imports.py
@@ -1,0 +1,9 @@
+"""Fixture: star imports."""
+
+from myproject.models import *  # noqa: F403
+
+
+class Child(Base):  # noqa: F405
+    """Base is not explicitly tracked — should not trigger INH001."""
+
+    pass

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+from pathlib import Path
 
 import pytest
 
@@ -16,6 +17,13 @@ from flake8_inheritance.visitors import (
     InheritanceVisitor,
     collect_module_class_names,
 )
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> str:
+    """Read and return the contents of a fixture file."""
+    return (FIXTURES_DIR / name).read_text()
 
 
 def track_imports(source: str) -> ImportTracker:
@@ -239,10 +247,7 @@ class TestINH001DynamicBases:
     """Dynamic base classes should be silently skipped."""
 
     def test_dynamic_base_skipped(self) -> None:
-        source = """\
-class Child(get_base()):
-    pass
-"""
+        source = _read_fixture("dynamic_bases.py")
         assert collect_errors(source) == []
 
     def test_dynamic_base_with_regular_base(self) -> None:
@@ -388,18 +393,7 @@ class TestINH002PureABC:
     """Pure ABCs (only abstract methods) should not be flagged."""
 
     def test_pure_abc_passes(self) -> None:
-        source = """\
-from abc import ABC, abstractmethod
-
-class MyABC(ABC):
-    @abstractmethod
-    def do_thing(self):
-        pass
-
-    @abstractmethod
-    def do_other(self):
-        pass
-"""
+        source = _read_fixture("pure_abc.py")
         assert collect_inh002_errors(source) == []
 
     def test_empty_abc_passes(self) -> None:
@@ -844,12 +838,7 @@ class TestStarImports:
 
     def test_star_import_no_crash(self) -> None:
         """``from myproject.models import *`` must not crash."""
-        source = """\
-from myproject.models import *
-
-class Child(Base):
-    pass
-"""
+        source = _read_fixture("star_imports.py")
         # Should not raise — star imports are silently recorded
         errors = collect_errors(source, project_package="myproject")
         # "Base" is not explicitly imported, so it's unknown — no error
@@ -897,11 +886,13 @@ class TestEmptyAndNoClassFiles:
     """Empty files and files with no class definitions."""
 
     def test_empty_file_inh001(self) -> None:
-        errors = collect_errors("")
+        source = _read_fixture("empty_file.py")
+        errors = collect_errors(source)
         assert errors == []
 
     def test_empty_file_inh002(self) -> None:
-        errors = collect_inh002_errors("")
+        source = _read_fixture("empty_file.py")
+        errors = collect_inh002_errors(source)
         assert errors == []
 
     def test_file_with_only_imports(self) -> None:
@@ -913,13 +904,7 @@ from collections import OrderedDict
         assert collect_inh002_errors(source) == []
 
     def test_file_with_only_functions(self) -> None:
-        source = """\
-def foo():
-    return 42
-
-def bar(x):
-    return x + 1
-"""
+        source = _read_fixture("no_classes.py")
         assert collect_errors(source) == []
         assert collect_inh002_errors(source) == []
 
@@ -932,7 +917,8 @@ z = [1, 2, 3]
         assert collect_errors(source) == []
 
     def test_collect_module_class_names_empty(self) -> None:
-        tree = ast.parse("")
+        source = _read_fixture("empty_file.py")
+        tree = ast.parse(source)
         assert collect_module_class_names(tree) == set()
 
     def test_collect_module_class_names_no_classes(self) -> None:

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -23,7 +23,7 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 def _read_fixture(name: str) -> str:
     """Read and return the contents of a fixture file."""
-    return (FIXTURES_DIR / name).read_text()
+    return (FIXTURES_DIR / name).read_text(encoding="utf-8")
 
 
 def track_imports(source: str) -> ImportTracker:


### PR DESCRIPTION
Populate tests/fixtures/ with 10 standalone .py files covering internal
inheritance, external inheritance, pure/impure ABCs, mixed bases, import
aliases, star imports, dynamic bases, empty file, and no-classes scenarios.
Refactor 6 existing tests in test_visitors.py to read from fixture files
instead of inline strings. Add mypy and ruff overrides to exclude fixture
files from strict checking since they are intentionally incomplete sample code.

https://claude.ai/code/session_01DdcAG8YPFcJkqTWMim2F1M