### PR TITLE
Write README with overview, install, quickstart, and error code docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ pip install flake8-inheritance
    project-packages = "myproject"
    ```
 
-   Without this option only same-file inheritance is flagged; cross-module
-   inheritance from your own packages is silently allowed.
+   Without this option, same-file inheritance and relative imports
+   (e.g. `from .models import Base`) are still flagged. However,
+   absolute imports from your own packages are treated as external
+   and silently allowed.
 
 3. **Run** Flake8:
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,138 @@
 # flake8-inheritance
 
-A Flake8 plugin that enforces composition over inheritance in Python codebases.
+A Flake8 plugin that nudges you toward composition over inheritance.
+It detects when classes inherit from concrete internal classes — cases where
+composition would reduce coupling — and flags concrete methods in abstract
+base classes that should remain pure interfaces.
 
 > **Status:** Under development. Not yet published to PyPI.
 
-## What it does
-
-`flake8-inheritance` distinguishes between *necessary* inheritance (from external
-frameworks like Pydantic or SQLAlchemy) and *discretionary* inheritance (from internal
-project classes where composition would be more appropriate). It flags the latter.
-
 ## Installation
 
-Not yet available. See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup.
+```bash
+pip install flake8-inheritance
+```
+
+## Quickstart
+
+1. **Install** the plugin (it registers itself with Flake8 automatically):
+
+   ```bash
+   pip install flake8-inheritance
+   ```
+
+2. **Configure** `--project-packages` so the plugin knows which imports
+   are part of your project. In `setup.cfg`, `.flake8`, or `pyproject.toml`:
+
+   ```ini
+   # .flake8 or setup.cfg
+   [flake8]
+   project-packages = myproject
+   ```
+
+   ```toml
+   # pyproject.toml
+   [tool.flake8]
+   project-packages = "myproject"
+   ```
+
+   Without this option only same-file inheritance is flagged; cross-module
+   inheritance from your own packages is silently allowed.
+
+3. **Run** Flake8:
+
+   ```bash
+   flake8 src/
+   ```
+
+## Verify the plugin is loaded
+
+```bash
+flake8 --version
+```
+
+The output should include a line like:
+
+```text
+flake8-inheritance: X.Y.Z
+```
+
+## Error codes
+
+| Code   | Description                                                         |
+|--------|---------------------------------------------------------------------|
+| INH001 | Inheritance from an internal concrete class (use composition)       |
+| INH002 | Concrete method in an abstract base class (ABCs should be pure)     |
+
+### INH001 — inheritance from internal class
+
+Triggered when a class inherits from a concrete (non-abstract) class
+that lives in the same file or in one of the configured
+`--project-packages`.
+
+```python
+class Engine:
+    def start(self) -> None: ...
+
+# INH001: Inheritance from internal class 'Engine' is not allowed
+class TurboEngine(Engine):
+    def start(self) -> None: ...
+```
+
+**Fix:** replace inheritance with composition:
+
+```python
+class TurboEngine:
+    def __init__(self, engine: Engine) -> None:
+        self._engine = engine
+
+    def start(self) -> None:
+        self._engine.start()
+```
+
+### INH002 — concrete method in an ABC
+
+Triggered when a class that derives from `abc.ABC` (or uses
+`abc.ABCMeta`) defines a non-abstract method.
+
+```python
+from abc import ABC, abstractmethod
+
+class Animal(ABC):
+    @abstractmethod
+    def speak(self) -> str: ...
+
+    # INH002: ABC 'Animal' contains concrete method 'legs'
+    def legs(self) -> int:
+        return 4
+```
+
+**Fix:** make the method abstract, or move the default implementation
+into a concrete class.
+
+## Configuration
+
+### `--project-packages`
+
+Comma-separated list of top-level package names that belong to your
+project. The plugin uses this to distinguish your code from third-party
+libraries.
+
+```ini
+[flake8]
+project-packages = myproject,myproject_utils
+```
+
+### `--inh002-allowed-dunders`
+
+Comma-separated list of dunder method names that are permitted as
+concrete methods in ABCs (e.g., `__init__`, `__repr__`).
+
+```ini
+[flake8]
+inh002-allowed-dunders = __init__,__repr__
+```
+
+## License
+
+BSD-3-Clause

--- a/README.md
+++ b/README.md
@@ -22,18 +22,12 @@ pip install flake8-inheritance
    ```
 
 2. **Configure** `--project-packages` so the plugin knows which imports
-   are part of your project. In `setup.cfg`, `.flake8`, or `pyproject.toml`:
+   are part of your project. Add it to `.flake8` or `setup.cfg`:
 
    ```ini
    # .flake8 or setup.cfg
    [flake8]
    project-packages = myproject
-   ```
-
-   ```toml
-   # pyproject.toml
-   [tool.flake8]
-   project-packages = "myproject"
    ```
 
    Without this option, same-file inheritance and relative imports

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -1281,3 +1281,42 @@ class Child(LocalBase, Mixin, Model):
         errors = collect_errors(source, project_package="myproject")
         expected = ["LocalBase", "Mixin", "Model"]
         assert flagged_bases(errors) == expected
+
+
+class TestINH001ZeroConfigBehavior:
+    """Zero-config mode flags same-file and relative-import inheritance.
+
+    Without --project-packages, absolute imports from the user's own
+    packages are treated as external and silently allowed.
+    """
+
+    def test_same_file_flagged_without_project_packages(self) -> None:
+        source = """\
+class Base:
+    pass
+
+class Child(Base):
+    pass
+"""
+        errors = collect_errors(source, project_package=None)
+        assert flagged_bases(errors) == ["Base"]
+
+    def test_relative_import_flagged_without_project_packages(self) -> None:
+        source = """\
+from .models import Base
+
+class Child(Base):
+    pass
+"""
+        errors = collect_errors(source, project_package=None)
+        assert flagged_bases(errors) == ["Base"]
+
+    def test_absolute_project_import_allowed_without_project_packages(self) -> None:
+        source = """\
+from myproject.models import Base
+
+class Child(Base):
+    pass
+"""
+        errors = collect_errors(source, project_package=None)
+        assert flagged_bases(errors) == []


### PR DESCRIPTION
Replaces the placeholder README with a complete document covering:
installation, three-step quickstart (install, configure
--project-packages, run), plugin verification, INH001/INH002 error
code explanations with examples and fixes, and configuration options.

https://claude.ai/code/session_01VfQRQgqKDb3xJLbjYg6Zho