### PR TITLE
docs: expand README configuration reference and add gradual-adoption guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ into a concrete class.
 
 ## Configuration
 
+This section documents every plugin option and the most common Flake8-native
+settings used to adopt `flake8-inheritance` in real projects.
+
+### Defaults at a glance
+
+| Option | Default | Meaning |
+|---|---|---|
+| `--project-packages` | empty | Absolute imports are external unless package is configured |
+| `--inh002-allowed-dunders` | `__init__` | Only `__init__` may be concrete in an ABC |
+
 ### `--project-packages`
 
 Comma-separated list of top-level package names that belong to your
@@ -119,6 +129,16 @@ libraries.
 project-packages = myproject,myproject_utils
 ```
 
+**Default:** empty (unset)
+
+When left unset, the plugin still flags:
+
+- inheritance from classes defined in the same file
+- inheritance via relative imports (for example, `from .base import Base`)
+
+But it treats absolute imports as external unless their top-level package is
+listed here.
+
 ### `--inh002-allowed-dunders`
 
 Comma-separated list of dunder method names that are permitted as
@@ -127,6 +147,95 @@ concrete methods in ABCs (e.g., `__init__`, `__repr__`).
 ```ini
 [flake8]
 inh002-allowed-dunders = __init__,__repr__
+```
+
+**Default:** `__init__`
+
+## Full configuration reference by file format
+
+You can configure these options in whichever Flake8 config style your project
+uses.
+
+### `.flake8`
+
+```ini
+[flake8]
+project-packages = myproject,myproject_utils
+inh002-allowed-dunders = __init__,__repr__
+
+# Flake8-native filtering controls
+select = INH
+extend-ignore = E203
+per-file-ignores =
+    tests/*:INH001
+```
+
+### `setup.cfg`
+
+```ini
+[flake8]
+project-packages = myproject,myproject_utils
+inh002-allowed-dunders = __init__,__repr__
+
+# Flake8-native filtering controls
+select = INH,B,C,E,F,W
+extend-ignore = E203,W503
+per-file-ignores =
+    tests/*:INH001
+    src/myproject/legacy/*.py:INH001,INH002
+```
+
+### `pyproject.toml` (with `flake8-pyproject`)
+
+Flake8 does not read `pyproject.toml` natively. Use
+[`flake8-pyproject`](https://pypi.org/project/flake8-pyproject/) to enable
+this format.
+
+```toml
+[tool.flake8]
+project-packages = ["myproject", "myproject_utils"]
+inh002-allowed-dunders = ["__init__", "__repr__"]
+
+# Flake8-native filtering controls
+select = ["INH", "E", "F", "W"]
+extend-ignore = ["E203", "W503"]
+per-file-ignores = [
+  "tests/*:INH001",
+  "src/myproject/legacy/*.py:INH001,INH002",
+]
+```
+
+## Flake8-native options commonly used with this plugin
+
+These are provided by Flake8 itself (not this plugin), but they are important
+for adoption:
+
+- `--select`: run only selected code families (for example, `--select=INH` to
+  focus exclusively on inheritance rules).
+- `--extend-ignore`: suppress specific codes while keeping defaults.
+- `--per-file-ignores`: carve out exceptions for known legacy paths.
+
+## Gradual Adoption (report-only workflow)
+
+For existing codebases, adopt incrementally:
+
+1. Start in **report-only mode** by running Flake8 with `--select=INH` in CI,
+   but do not fail the build yet.
+2. Track and review findings; classify true positives vs intentional patterns.
+3. Add temporary `per-file-ignores` for legacy modules to keep signal high.
+4. Fix violations in new/changed code first.
+5. Remove ignores over time and then enforce INH rules as required checks.
+
+Example report-only CI command:
+
+```bash
+flake8 --select=INH src tests || true
+```
+
+Example enforced command once ready:
+
+```bash
+flake8 --select=INH src tests
 ```
 
 ## License


### PR DESCRIPTION
### Motivation

- Provide a complete configuration reference so users can configure the plugin consistently across `.flake8`, `setup.cfg`, and `pyproject.toml`.
- Explain default behaviors for `--project-packages` and `--inh002-allowed-dunders` and give a clear, low-friction path for gradual adoption in CI.

### Description

- Updated `README.md` to add a defaults table documenting `--project-packages` and `--inh002-allowed-dunders` and their default values.
- Added concrete configuration examples for `.flake8`, `setup.cfg`, and `pyproject.toml` (via `flake8-pyproject`).
- Documented Flake8-native options (`--select`, `--extend-ignore`, `--per-file-ignores`) in the plugin context and added a "Gradual Adoption" section with report-only workflow and CI command examples.

### Testing

- Ran `uv run pre-commit run --all-files` and the hooks passed.
- Ran `uv run pytest` and all tests passed (`157 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c09bdc498832688844524765065a2)