### PR TITLE
docs: align README option defaults with implementation and normalize Configuration headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ settings used to adopt `flake8-inheritance` in real projects.
 
 | Option | Default | Meaning |
 |---|---|---|
-| `--project-packages` | empty | Absolute imports are external unless package is configured |
+| `--project-packages` | empty (unset) | Absolute imports are external unless package is configured |
 | `--inh002-allowed-dunders` | unset (`None`) | All dunder methods are allowed in ABCs |
 
 ### `--project-packages`
@@ -131,7 +131,7 @@ project-packages = myproject,myproject_utils
 
 **Default:** empty (unset)
 
-When left unset, the plugin still flags:
+When left unset (or set to an explicit empty value), the plugin still flags:
 
 - inheritance from classes defined in the same file
 - inheritance via relative imports (for example, `from .base import Base`)
@@ -170,7 +170,7 @@ project-packages = myproject,myproject_utils
 inh002-allowed-dunders = __init__,__repr__
 
 # Flake8-native filtering controls
-select = INH
+select = INH,E,F,W
 extend-ignore = E203
 per-file-ignores =
     tests/*:INH001

--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ into a concrete class.
 
 ## Configuration
 
+This section documents every plugin option and the most common Flake8-native
+settings used to adopt `flake8-inheritance` in real projects.
+
+### Defaults at a glance
+
+| Option | Default | Meaning |
+|---|---|---|
+| `--project-packages` | empty | Absolute imports are external unless package is configured |
+| `--inh002-allowed-dunders` | unset (`None`) | All dunder methods are allowed in ABCs |
+
 ### `--project-packages`
 
 Comma-separated list of top-level package names that belong to your
@@ -119,6 +129,16 @@ libraries.
 project-packages = myproject,myproject_utils
 ```
 
+**Default:** empty (unset)
+
+When left unset, the plugin still flags:
+
+- inheritance from classes defined in the same file
+- inheritance via relative imports (for example, `from .base import Base`)
+
+But it treats absolute imports as external unless their top-level package is
+listed here.
+
 ### `--inh002-allowed-dunders`
 
 Comma-separated list of dunder method names that are permitted as
@@ -127,6 +147,101 @@ concrete methods in ABCs (e.g., `__init__`, `__repr__`).
 ```ini
 [flake8]
 inh002-allowed-dunders = __init__,__repr__
+```
+
+**Default:** unset (`None`), which allows all dunder methods.
+
+This option has three useful states:
+
+- **Unset** (no config value): all dunder methods are allowed.
+- **Empty string** (`inh002-allowed-dunders =`): no dunder methods are allowed.
+- **Non-empty list**: only listed dunder methods are allowed.
+
+### Full configuration reference by file format
+
+You can configure these options in whichever Flake8 config style your project
+uses.
+
+#### `.flake8`
+
+```ini
+[flake8]
+project-packages = myproject,myproject_utils
+inh002-allowed-dunders = __init__,__repr__
+
+# Flake8-native filtering controls
+select = INH
+extend-ignore = E203
+per-file-ignores =
+    tests/*:INH001
+```
+
+#### `setup.cfg`
+
+```ini
+[flake8]
+project-packages = myproject,myproject_utils
+inh002-allowed-dunders = __init__,__repr__
+
+# Flake8-native filtering controls
+select = INH,B,C,E,F,W
+extend-ignore = E203,W503
+per-file-ignores =
+    tests/*:INH001
+    src/myproject/legacy/*.py:INH001,INH002
+```
+
+#### `pyproject.toml` (with `flake8-pyproject`)
+
+Flake8 does not read `pyproject.toml` natively. Use
+[`flake8-pyproject`](https://pypi.org/project/flake8-pyproject/) to enable
+this format.
+
+```toml
+[tool.flake8]
+project-packages = ["myproject", "myproject_utils"]
+inh002-allowed-dunders = ["__init__", "__repr__"]
+
+# Flake8-native filtering controls
+select = ["INH", "E", "F", "W"]
+extend-ignore = ["E203", "W503"]
+per-file-ignores = [
+  "tests/*:INH001",
+  "src/myproject/legacy/*.py:INH001,INH002",
+]
+```
+
+### Flake8-native options commonly used with this plugin
+
+These are provided by Flake8 itself (not this plugin), but they are important
+for adoption:
+
+- `--select`: run only selected code families (for example, `--select=INH` to
+  focus exclusively on inheritance rules).
+- `--extend-ignore`: suppress specific codes while keeping defaults.
+- `--per-file-ignores`: carve out exceptions for known legacy paths.
+
+### Gradual Adoption (report-only workflow)
+
+For existing codebases, adopt incrementally:
+
+1. Start in **report-only mode** by running Flake8 with `--select=INH` in CI,
+   but do not fail the build yet.
+2. Track and review findings; classify true positives vs intentional patterns.
+3. Add temporary `per-file-ignores` for legacy modules to keep signal high.
+4. Fix violations in new/changed code first.
+5. Remove ignores over time and then enforce INH rules as required checks.
+
+Example report-only CI command:
+
+```bash
+flake8 --select=INH src tests || true
+```
+
+Example enforced command once ready:
+
+```bash
+flake8 --select=INH src tests
 ```
 
 ## License


### PR DESCRIPTION
### Motivation

- The README stated that `--inh002-allowed-dunders` defaulted to `__init__`, but the runtime default is `None`, which allows all dunder methods, so the docs needed to match the implementation and reviewer feedback. 
- The README had inconsistent heading levels that split configuration guidance across top-level sections, making the configuration reference harder to navigate. 
- A short, explicit explanation of the three semantic states for `--inh002-allowed-dunders` (unset / empty / non-empty) was requested for clarity. 

### Description

- Updated `README.md` to document `--inh002-allowed-dunders` default as unset (`None`) and clarified that unset means all dunder methods are allowed. 
- Added a concise three-state explanation for `--inh002-allowed-dunders` describing the meanings of unset, empty string, and non-empty list. 
- Normalized heading levels so the format-specific examples, Flake8-native options, and Gradual Adoption guidance are nested under the main `## Configuration` section (`###` / `####`) for a consistent TOC and structure. 
- Confirmed the change aligns with the implementation where `InheritanceChecker.add_options` sets the option default to `None` and `ABCPurityVisitor` treats `None` as allowing all dunders (no code changes were necessary). 

### Testing

- Ran `uv run pre-commit run --all-files` and the pre-commit checks passed. 
- Ran `uv run pytest` and the full test suite passed with `157 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c09bdc498832688844524765065a2)