### PR TITLE
Add smoke tests against real-world codebases (CPython, requests, FastAPI)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,9 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = ["-q", "--disable-warnings"]
+addopts = ["-q", "--disable-warnings", "-m", "not slow"]
 timeout = 5
+markers = ["slow: marks tests that clone external repos (deselect with '-m \"not slow\"')"]
 
 [tool.coverage.run]
 branch = true

--- a/tests/test_smoke_real_codebases.py
+++ b/tests/test_smoke_real_codebases.py
@@ -21,9 +21,12 @@ from __future__ import annotations
 
 import subprocess
 import sys
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 slow = pytest.mark.slow
 
@@ -46,6 +49,7 @@ def _run_flake8(target: Path) -> subprocess.CompletedProcess[str]:
         ],
         capture_output=True,
         text=True,
+        check=False,
     )
 
 

--- a/tests/test_smoke_real_codebases.py
+++ b/tests/test_smoke_real_codebases.py
@@ -1,0 +1,80 @@
+"""Smoke tests: run the plugin against real-world open-source codebases.
+
+These tests clone well-known projects into a temporary directory and run
+``flake8 --select=INH --enable-extensions=INH`` against them.  The goal is
+to verify the plugin completes *without unhandled exceptions* — the
+violations themselves are expected (these projects use inheritance heavily).
+
+Every test is marked ``@pytest.mark.slow`` so the default ``pytest`` run
+skips them.  Execute with::
+
+    uv run pytest -m slow --timeout 300
+
+Results recorded on 2026-02-11
+-------------------------------
+* **CPython Lib/** — 3 716 violations (3 620 INH001, 96 INH002), 0 crashes
+* **requests src/** — 36 violations (all INH001), 0 crashes
+* **FastAPI fastapi/** — 54 violations (all INH001), 0 crashes
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+slow = pytest.mark.slow
+
+
+def _clone(url: str, dest: Path) -> None:
+    subprocess.check_call(  # noqa: S603
+        ["git", "clone", "--depth", "1", "--quiet", url, str(dest)],  # noqa: S607
+    )
+
+
+def _run_flake8(target: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "flake8",
+            "--select=INH",
+            "--enable-extensions=INH",
+            str(target),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+@slow
+@pytest.mark.timeout(300)
+def test_cpython_stdlib(tmp_path: Path) -> None:
+    repo = tmp_path / "cpython"
+    _clone("https://github.com/python/cpython.git", repo)
+    result = _run_flake8(repo / "Lib")
+    # Exit code 1 = violations found (expected).  Any other non-zero is a crash.
+    assert result.returncode in (0, 1), f"flake8 crashed:\n{result.stderr}"
+    assert "Traceback" not in result.stderr
+
+
+@slow
+@pytest.mark.timeout(120)
+def test_requests(tmp_path: Path) -> None:
+    repo = tmp_path / "requests"
+    _clone("https://github.com/psf/requests.git", repo)
+    result = _run_flake8(repo / "src")
+    assert result.returncode in (0, 1), f"flake8 crashed:\n{result.stderr}"
+    assert "Traceback" not in result.stderr
+
+
+@slow
+@pytest.mark.timeout(120)
+def test_fastapi(tmp_path: Path) -> None:
+    repo = tmp_path / "fastapi"
+    _clone("https://github.com/fastapi/fastapi.git", repo)
+    result = _run_flake8(repo / "fastapi")
+    assert result.returncode in (0, 1), f"flake8 crashed:\n{result.stderr}"
+    assert "Traceback" not in result.stderr


### PR DESCRIPTION
Run the plugin against three well-known open-source projects to verify
it completes without unhandled exceptions. Results:
- CPython Lib/: 3716 violations (3620 INH001, 96 INH002), 0 crashes
- requests src/: 36 violations (all INH001), 0 crashes
- FastAPI fastapi/: 54 violations (all INH001), 0 crashes

Tests are marked @pytest.mark.slow and excluded from the default test
run. Execute with: uv run pytest -m slow --timeout 300

https://claude.ai/code/session_01QhEkieNBBZ3GqZ26kvCg9P