### PR TITLE
Finalize CHANGELOG for v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-02-11
+
 ### Added
 
-- Initial project skeleton with flake8 entry point registration.
+- **INH001** rule: flag inheritance from concrete internal classes (same-file,
+  relative imports, and project-package imports).
+- **INH002** rule: flag concrete (non-abstract) methods in abstract base classes
+  (`abc.ABC` / `abc.ABCMeta`).
+- `--project-packages` option to declare which top-level packages are internal,
+  enabling INH001 detection for absolute imports from your own code.
+- `--inh002-allowed-dunders` option to allowlist specific dunder methods as
+  concrete implementations in ABCs.
+- Pre-commit hook support (`.pre-commit-hooks.yaml`) with hook id
+  `flake8-inheritance`.
+- Off-by-default plugin; enable with `--enable-extensions=INH`.
 - Architecture Decision Records using decree.
+- Initial project skeleton with flake8 entry point registration.


### PR DESCRIPTION
Move [Unreleased] to [0.1.0] with today's date. Document all added
features: INH001/INH002 rules, --project-packages and
--inh002-allowed-dunders options, pre-commit hook support, and
off-by-default behavior.

https://claude.ai/code/session_012uM7s4A73Nt1DKAuBaYFSA